### PR TITLE
fix: Gsm initialize

### DIFF
--- a/src/contracts/facilitators/gsm/Gsm.sol
+++ b/src/contracts/facilitators/gsm/Gsm.sol
@@ -92,7 +92,11 @@ contract Gsm is AccessControl, VersionedInitializable, EIP712, IGsm {
    * @param underlyingAsset The address of the collateral asset
    * @param priceStrategy The address of the price strategy
    */
-  constructor(address ghoToken, address underlyingAsset, address priceStrategy) EIP712('GSM', '1') initializer {
+  constructor(
+    address ghoToken,
+    address underlyingAsset,
+    address priceStrategy
+  ) EIP712('GSM', '1') initializer {
     require(ghoToken != address(0), 'ZERO_ADDRESS_NOT_VALID');
     require(underlyingAsset != address(0), 'ZERO_ADDRESS_NOT_VALID');
     require(

--- a/src/contracts/facilitators/gsm/Gsm.sol
+++ b/src/contracts/facilitators/gsm/Gsm.sol
@@ -92,7 +92,7 @@ contract Gsm is AccessControl, VersionedInitializable, EIP712, IGsm {
    * @param underlyingAsset The address of the collateral asset
    * @param priceStrategy The address of the price strategy
    */
-  constructor(address ghoToken, address underlyingAsset, address priceStrategy) EIP712('GSM', '1') {
+  constructor(address ghoToken, address underlyingAsset, address priceStrategy) EIP712('GSM', '1') initializer {
     require(ghoToken != address(0), 'ZERO_ADDRESS_NOT_VALID');
     require(underlyingAsset != address(0), 'ZERO_ADDRESS_NOT_VALID');
     require(

--- a/tests/unit/TestGhoBase.t.sol
+++ b/tests/unit/TestGhoBase.t.sol
@@ -279,6 +279,12 @@ contract TestGhoBase is Test, Constants, Events {
       address(USDX_4626_TOKEN),
       address(GHO_GSM_4626_FIXED_PRICE_STRATEGY)
     );
+    AdminUpgradeabilityProxy gsm4626Proxy = new AdminUpgradeabilityProxy(
+      address(GHO_GSM_4626),
+      SHORT_EXECUTOR,
+      ''
+    );
+    GHO_GSM_4626 = Gsm4626(address(gsm4626Proxy));
     GHO_GSM_4626.initialize(
       address(this),
       TREASURY,

--- a/tests/unit/TestGsm.t.sol
+++ b/tests/unit/TestGsm.t.sol
@@ -50,6 +50,11 @@ contract TestGsm is TestGhoBase {
       address(USDX_TOKEN),
       address(GHO_GSM_FIXED_PRICE_STRATEGY)
     );
+    gsm = Gsm(address(new AdminUpgradeabilityProxy(
+      address(gsm),
+      SHORT_EXECUTOR,
+      ''
+    )));
     vm.expectEmit(true, true, true, true, address(gsm));
     emit RoleGranted(DEFAULT_ADMIN_ROLE, address(this), address(this));
     vm.expectEmit(true, true, false, true, address(gsm));
@@ -66,6 +71,11 @@ contract TestGsm is TestGhoBase {
       address(USDX_TOKEN),
       address(GHO_GSM_FIXED_PRICE_STRATEGY)
     );
+    gsm = Gsm(address(new AdminUpgradeabilityProxy(
+      address(gsm),
+      SHORT_EXECUTOR,
+      ''
+    )));
     vm.expectRevert('ZERO_ADDRESS_NOT_VALID');
     gsm.initialize(address(0), TREASURY, DEFAULT_GSM_USDX_EXPOSURE, address(GHO_RESERVE));
   }
@@ -76,6 +86,11 @@ contract TestGsm is TestGhoBase {
       address(USDX_TOKEN),
       address(GHO_GSM_FIXED_PRICE_STRATEGY)
     );
+    gsm = Gsm(address(new AdminUpgradeabilityProxy(
+      address(gsm),
+      SHORT_EXECUTOR,
+      ''
+    )));
     vm.expectRevert('ZERO_ADDRESS_NOT_VALID');
     gsm.initialize(address(this), TREASURY, DEFAULT_GSM_USDX_EXPOSURE, address(0));
   }
@@ -86,6 +101,11 @@ contract TestGsm is TestGhoBase {
       address(USDX_TOKEN),
       address(GHO_GSM_FIXED_PRICE_STRATEGY)
     );
+    gsm = Gsm(address(new AdminUpgradeabilityProxy(
+      address(gsm),
+      SHORT_EXECUTOR,
+      ''
+    )));
     gsm.initialize(address(this), TREASURY, DEFAULT_GSM_USDX_EXPOSURE, address(GHO_RESERVE));
     vm.expectRevert('Contract instance has already been initialized');
     gsm.initialize(address(this), TREASURY, DEFAULT_GSM_USDX_EXPOSURE, address(GHO_RESERVE));
@@ -368,6 +388,11 @@ contract TestGsm is TestGhoBase {
       address(USDX_TOKEN),
       address(GHO_GSM_FIXED_PRICE_STRATEGY)
     );
+    gsm = Gsm(address(new AdminUpgradeabilityProxy(
+      address(gsm),
+      SHORT_EXECUTOR,
+      ''
+    )));
     gsm.initialize(address(this), TREASURY, DEFAULT_GSM_USDX_EXPOSURE, address(GHO_RESERVE));
     GHO_RESERVE.addEntity(address(gsm));
     uint256 defaultCapInUsdx = DEFAULT_CAPACITY / (10 ** (18 - USDX_TOKEN.decimals()));
@@ -388,6 +413,11 @@ contract TestGsm is TestGhoBase {
       address(USDX_TOKEN),
       address(GHO_GSM_FIXED_PRICE_STRATEGY)
     );
+    gsm = Gsm(address(new AdminUpgradeabilityProxy(
+      address(gsm),
+      SHORT_EXECUTOR,
+      ''
+    )));
     gsm.initialize(address(this), TREASURY, DEFAULT_GSM_USDX_EXPOSURE - 1, address(GHO_RESERVE));
     GHO_TOKEN.addFacilitator(address(gsm), 'GSM Modified Exposure Cap', DEFAULT_CAPACITY);
 
@@ -1073,6 +1103,11 @@ contract TestGsm is TestGhoBase {
       address(USDX_TOKEN),
       address(GHO_GSM_FIXED_PRICE_STRATEGY)
     );
+    gsm = Gsm(address(new AdminUpgradeabilityProxy(
+      address(gsm),
+      SHORT_EXECUTOR,
+      ''
+    )));
     vm.expectRevert(bytes('ZERO_ADDRESS_NOT_VALID'));
     gsm.initialize(address(this), address(0), DEFAULT_GSM_USDX_EXPOSURE, address(GHO_RESERVE));
   }

--- a/tests/unit/TestGsm.t.sol
+++ b/tests/unit/TestGsm.t.sol
@@ -50,11 +50,7 @@ contract TestGsm is TestGhoBase {
       address(USDX_TOKEN),
       address(GHO_GSM_FIXED_PRICE_STRATEGY)
     );
-    gsm = Gsm(address(new AdminUpgradeabilityProxy(
-      address(gsm),
-      SHORT_EXECUTOR,
-      ''
-    )));
+    gsm = Gsm(address(new AdminUpgradeabilityProxy(address(gsm), SHORT_EXECUTOR, '')));
     vm.expectEmit(true, true, true, true, address(gsm));
     emit RoleGranted(DEFAULT_ADMIN_ROLE, address(this), address(this));
     vm.expectEmit(true, true, false, true, address(gsm));
@@ -71,11 +67,7 @@ contract TestGsm is TestGhoBase {
       address(USDX_TOKEN),
       address(GHO_GSM_FIXED_PRICE_STRATEGY)
     );
-    gsm = Gsm(address(new AdminUpgradeabilityProxy(
-      address(gsm),
-      SHORT_EXECUTOR,
-      ''
-    )));
+    gsm = Gsm(address(new AdminUpgradeabilityProxy(address(gsm), SHORT_EXECUTOR, '')));
     vm.expectRevert('ZERO_ADDRESS_NOT_VALID');
     gsm.initialize(address(0), TREASURY, DEFAULT_GSM_USDX_EXPOSURE, address(GHO_RESERVE));
   }
@@ -86,11 +78,7 @@ contract TestGsm is TestGhoBase {
       address(USDX_TOKEN),
       address(GHO_GSM_FIXED_PRICE_STRATEGY)
     );
-    gsm = Gsm(address(new AdminUpgradeabilityProxy(
-      address(gsm),
-      SHORT_EXECUTOR,
-      ''
-    )));
+    gsm = Gsm(address(new AdminUpgradeabilityProxy(address(gsm), SHORT_EXECUTOR, '')));
     vm.expectRevert('ZERO_ADDRESS_NOT_VALID');
     gsm.initialize(address(this), TREASURY, DEFAULT_GSM_USDX_EXPOSURE, address(0));
   }
@@ -101,11 +89,7 @@ contract TestGsm is TestGhoBase {
       address(USDX_TOKEN),
       address(GHO_GSM_FIXED_PRICE_STRATEGY)
     );
-    gsm = Gsm(address(new AdminUpgradeabilityProxy(
-      address(gsm),
-      SHORT_EXECUTOR,
-      ''
-    )));
+    gsm = Gsm(address(new AdminUpgradeabilityProxy(address(gsm), SHORT_EXECUTOR, '')));
     gsm.initialize(address(this), TREASURY, DEFAULT_GSM_USDX_EXPOSURE, address(GHO_RESERVE));
     vm.expectRevert('Contract instance has already been initialized');
     gsm.initialize(address(this), TREASURY, DEFAULT_GSM_USDX_EXPOSURE, address(GHO_RESERVE));
@@ -388,11 +372,7 @@ contract TestGsm is TestGhoBase {
       address(USDX_TOKEN),
       address(GHO_GSM_FIXED_PRICE_STRATEGY)
     );
-    gsm = Gsm(address(new AdminUpgradeabilityProxy(
-      address(gsm),
-      SHORT_EXECUTOR,
-      ''
-    )));
+    gsm = Gsm(address(new AdminUpgradeabilityProxy(address(gsm), SHORT_EXECUTOR, '')));
     gsm.initialize(address(this), TREASURY, DEFAULT_GSM_USDX_EXPOSURE, address(GHO_RESERVE));
     GHO_RESERVE.addEntity(address(gsm));
     uint256 defaultCapInUsdx = DEFAULT_CAPACITY / (10 ** (18 - USDX_TOKEN.decimals()));
@@ -413,11 +393,7 @@ contract TestGsm is TestGhoBase {
       address(USDX_TOKEN),
       address(GHO_GSM_FIXED_PRICE_STRATEGY)
     );
-    gsm = Gsm(address(new AdminUpgradeabilityProxy(
-      address(gsm),
-      SHORT_EXECUTOR,
-      ''
-    )));
+    gsm = Gsm(address(new AdminUpgradeabilityProxy(address(gsm), SHORT_EXECUTOR, '')));
     gsm.initialize(address(this), TREASURY, DEFAULT_GSM_USDX_EXPOSURE - 1, address(GHO_RESERVE));
     GHO_TOKEN.addFacilitator(address(gsm), 'GSM Modified Exposure Cap', DEFAULT_CAPACITY);
 
@@ -1103,11 +1079,7 @@ contract TestGsm is TestGhoBase {
       address(USDX_TOKEN),
       address(GHO_GSM_FIXED_PRICE_STRATEGY)
     );
-    gsm = Gsm(address(new AdminUpgradeabilityProxy(
-      address(gsm),
-      SHORT_EXECUTOR,
-      ''
-    )));
+    gsm = Gsm(address(new AdminUpgradeabilityProxy(address(gsm), SHORT_EXECUTOR, '')));
     vm.expectRevert(bytes('ZERO_ADDRESS_NOT_VALID'));
     gsm.initialize(address(this), address(0), DEFAULT_GSM_USDX_EXPOSURE, address(GHO_RESERVE));
   }

--- a/tests/unit/TestGsm4626.t.sol
+++ b/tests/unit/TestGsm4626.t.sol
@@ -46,11 +46,7 @@ contract TestGsm4626 is TestGhoBase {
       address(USDX_4626_TOKEN),
       address(GHO_GSM_4626_FIXED_PRICE_STRATEGY)
     );
-    gsm = Gsm4626(address(new AdminUpgradeabilityProxy(
-      address(gsm),
-      SHORT_EXECUTOR,
-      ''
-    )));
+    gsm = Gsm4626(address(new AdminUpgradeabilityProxy(address(gsm), SHORT_EXECUTOR, '')));
     vm.expectEmit(true, true, true, true, address(gsm));
     emit RoleGranted(DEFAULT_ADMIN_ROLE, address(this), address(this));
     vm.expectEmit(true, true, false, true, address(gsm));
@@ -65,11 +61,7 @@ contract TestGsm4626 is TestGhoBase {
       address(USDX_4626_TOKEN),
       address(GHO_GSM_4626_FIXED_PRICE_STRATEGY)
     );
-    gsm = Gsm4626(address(new AdminUpgradeabilityProxy(
-      address(gsm),
-      SHORT_EXECUTOR,
-      ''
-    )));
+    gsm = Gsm4626(address(new AdminUpgradeabilityProxy(address(gsm), SHORT_EXECUTOR, '')));
     gsm.initialize(address(this), TREASURY, DEFAULT_GSM_USDX_EXPOSURE, address(GHO_RESERVE));
     vm.expectRevert('Contract instance has already been initialized');
     gsm.initialize(address(this), TREASURY, DEFAULT_GSM_USDX_EXPOSURE, address(GHO_RESERVE));

--- a/tests/unit/TestGsm4626.t.sol
+++ b/tests/unit/TestGsm4626.t.sol
@@ -169,12 +169,7 @@ contract TestGsm4626 is TestGhoBase {
       address(USDX_4626_TOKEN),
       address(GHO_GSM_4626_FIXED_PRICE_STRATEGY)
     );
-    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
-      address(gsm),
-      SHORT_EXECUTOR,
-      ''
-    );
-    gsm = Gsm4626(address(gsmProxy));
+    gsm = Gsm4626(address(new AdminUpgradeabilityProxy(address(gsm), SHORT_EXECUTOR, '')));
     gsm.initialize(address(this), TREASURY, DEFAULT_GSM_USDX_EXPOSURE - 1, address(GHO_RESERVE));
     GHO_TOKEN.addFacilitator(address(gsm), 'GSM Modified Exposure Cap', DEFAULT_CAPACITY);
 

--- a/tests/unit/TestGsm4626.t.sol
+++ b/tests/unit/TestGsm4626.t.sol
@@ -46,6 +46,11 @@ contract TestGsm4626 is TestGhoBase {
       address(USDX_4626_TOKEN),
       address(GHO_GSM_4626_FIXED_PRICE_STRATEGY)
     );
+    gsm = Gsm4626(address(new AdminUpgradeabilityProxy(
+      address(gsm),
+      SHORT_EXECUTOR,
+      ''
+    )));
     vm.expectEmit(true, true, true, true, address(gsm));
     emit RoleGranted(DEFAULT_ADMIN_ROLE, address(this), address(this));
     vm.expectEmit(true, true, false, true, address(gsm));
@@ -60,6 +65,11 @@ contract TestGsm4626 is TestGhoBase {
       address(USDX_4626_TOKEN),
       address(GHO_GSM_4626_FIXED_PRICE_STRATEGY)
     );
+    gsm = Gsm4626(address(new AdminUpgradeabilityProxy(
+      address(gsm),
+      SHORT_EXECUTOR,
+      ''
+    )));
     gsm.initialize(address(this), TREASURY, DEFAULT_GSM_USDX_EXPOSURE, address(GHO_RESERVE));
     vm.expectRevert('Contract instance has already been initialized');
     gsm.initialize(address(this), TREASURY, DEFAULT_GSM_USDX_EXPOSURE, address(GHO_RESERVE));
@@ -167,6 +177,12 @@ contract TestGsm4626 is TestGhoBase {
       address(USDX_4626_TOKEN),
       address(GHO_GSM_4626_FIXED_PRICE_STRATEGY)
     );
+    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
+      address(gsm),
+      SHORT_EXECUTOR,
+      ''
+    );
+    gsm = Gsm4626(address(gsmProxy));
     gsm.initialize(address(this), TREASURY, DEFAULT_GSM_USDX_EXPOSURE - 1, address(GHO_RESERVE));
     GHO_TOKEN.addFacilitator(address(gsm), 'GSM Modified Exposure Cap', DEFAULT_CAPACITY);
 

--- a/tests/unit/TestGsm4626Edge.t.sol
+++ b/tests/unit/TestGsm4626Edge.t.sol
@@ -196,12 +196,7 @@ contract TestGsm4626Edge is TestGhoBase {
       address(USDX_4626_TOKEN),
       address(GHO_GSM_4626_FIXED_PRICE_STRATEGY)
     );
-    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
-      address(gsm),
-      SHORT_EXECUTOR,
-      ''
-    );
-    gsm = Gsm4626(address(gsmProxy));
+    gsm = Gsm4626(address(new AdminUpgradeabilityProxy(address(gsm), SHORT_EXECUTOR, '')));
     gsm.initialize(address(this), TREASURY, DEFAULT_GSM_USDX_EXPOSURE - 1, address(GHO_RESERVE));
     GHO_RESERVE.addEntity(address(gsm));
     GHO_RESERVE.setLimit(address(gsm), DEFAULT_CAPACITY);
@@ -230,12 +225,7 @@ contract TestGsm4626Edge is TestGhoBase {
       address(USDX_4626_TOKEN),
       address(GHO_GSM_4626_FIXED_PRICE_STRATEGY)
     );
-    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
-      address(gsm),
-      SHORT_EXECUTOR,
-      ''
-    );
-    gsm = Gsm4626(address(gsmProxy));
+    gsm = Gsm4626(address(new AdminUpgradeabilityProxy(address(gsm), SHORT_EXECUTOR, '')));
     gsm.initialize(address(this), TREASURY, DEFAULT_GSM_USDX_EXPOSURE - 1, address(GHO_RESERVE));
     GHO_RESERVE.addEntity(address(gsm));
     GHO_RESERVE.setLimit(address(gsm), DEFAULT_CAPACITY);

--- a/tests/unit/TestGsm4626Edge.t.sol
+++ b/tests/unit/TestGsm4626Edge.t.sol
@@ -196,6 +196,12 @@ contract TestGsm4626Edge is TestGhoBase {
       address(USDX_4626_TOKEN),
       address(GHO_GSM_4626_FIXED_PRICE_STRATEGY)
     );
+    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
+      address(gsm),
+      SHORT_EXECUTOR,
+      ''
+    );
+    gsm = Gsm4626(address(gsmProxy));
     gsm.initialize(address(this), TREASURY, DEFAULT_GSM_USDX_EXPOSURE - 1, address(GHO_RESERVE));
     GHO_RESERVE.addEntity(address(gsm));
     GHO_RESERVE.setLimit(address(gsm), DEFAULT_CAPACITY);
@@ -224,6 +230,12 @@ contract TestGsm4626Edge is TestGhoBase {
       address(USDX_4626_TOKEN),
       address(GHO_GSM_4626_FIXED_PRICE_STRATEGY)
     );
+    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
+      address(gsm),
+      SHORT_EXECUTOR,
+      ''
+    );
+    gsm = Gsm4626(address(gsmProxy));
     gsm.initialize(address(this), TREASURY, DEFAULT_GSM_USDX_EXPOSURE - 1, address(GHO_RESERVE));
     GHO_RESERVE.addEntity(address(gsm));
     GHO_RESERVE.setLimit(address(gsm), DEFAULT_CAPACITY);

--- a/tests/unit/TestGsmFullFlow.t.sol
+++ b/tests/unit/TestGsmFullFlow.t.sol
@@ -16,6 +16,7 @@ contract TestGsmFullFlow is TestGhoBase {
       address(USDX_TOKEN),
       address(GHO_GSM_FIXED_PRICE_STRATEGY)
     );
+    gsm = Gsm(address(new AdminUpgradeabilityProxy(address(gsm), SHORT_EXECUTOR, '')));
     gsm.initialize(address(this), TREASURY, DEFAULT_GSM_USDX_EXPOSURE, address(reserve));
 
     reserve.addEntity(address(gsm));

--- a/tests/unit/TestGsmSwapEdge.t.sol
+++ b/tests/unit/TestGsmSwapEdge.t.sol
@@ -19,12 +19,7 @@ contract TestGsmSwapEdge is TestGhoBase {
       5
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
-    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
-      address(gsm),
-      SHORT_EXECUTOR,
-      ''
-    );
-    gsm = Gsm(address(gsmProxy));
+    gsm = Gsm(address(new AdminUpgradeabilityProxy(address(gsm), SHORT_EXECUTOR, '')));
     gsm.initialize(address(this), TREASURY, type(uint128).max, address(GHO_RESERVE));
     GHO_RESERVE.addEntity(address(gsm));
     GHO_RESERVE.setLimit(address(gsm), type(uint128).max);
@@ -83,12 +78,7 @@ contract TestGsmSwapEdge is TestGhoBase {
       18
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
-    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
-      address(gsm),
-      SHORT_EXECUTOR,
-      ''
-    );
-    gsm = Gsm(address(gsmProxy));
+    gsm = Gsm(address(new AdminUpgradeabilityProxy(address(gsm), SHORT_EXECUTOR, '')));
     gsm.initialize(address(this), TREASURY, 100_000_000e18, address(GHO_RESERVE));
     gsm.updateFeeStrategy(address(newFeeStrategy));
     GHO_RESERVE.addEntity(address(gsm));
@@ -124,12 +114,7 @@ contract TestGsmSwapEdge is TestGhoBase {
       18
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
-    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
-      address(gsm),
-      SHORT_EXECUTOR,
-      ''
-    );
-    gsm = Gsm(address(gsmProxy));
+    gsm = Gsm(address(new AdminUpgradeabilityProxy(address(gsm), SHORT_EXECUTOR, '')));
     gsm.initialize(address(this), TREASURY, 100_000_000e18, address(GHO_RESERVE));
     gsm.updateFeeStrategy(address(newFeeStrategy));
     GHO_RESERVE.addEntity(address(gsm));
@@ -175,12 +160,7 @@ contract TestGsmSwapEdge is TestGhoBase {
       24 // decimals
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
-    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
-      address(gsm),
-      SHORT_EXECUTOR,
-      ''
-    );
-    gsm = Gsm(address(gsmProxy));
+    gsm = Gsm(address(new AdminUpgradeabilityProxy(address(gsm), SHORT_EXECUTOR, '')));
     gsm.initialize(ALICE, TREASURY, 1_000_000e24, address(GHO_RESERVE));
     GHO_RESERVE.addEntity(address(gsm));
     GHO_RESERVE.setLimit(address(gsm), 100_000_000 ether);
@@ -231,12 +211,7 @@ contract TestGsmSwapEdge is TestGhoBase {
       24 // decimals
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
-    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
-      address(gsm),
-      SHORT_EXECUTOR,
-      ''
-    );
-    gsm = Gsm(address(gsmProxy));
+    gsm = Gsm(address(new AdminUpgradeabilityProxy(address(gsm), SHORT_EXECUTOR, '')));
     gsm.initialize(ALICE, TREASURY, 1_000_000e24, address(GHO_RESERVE));
     GHO_RESERVE.addEntity(address(gsm));
     GHO_RESERVE.setLimit(address(gsm), 100_000_000 ether);
@@ -282,12 +257,7 @@ contract TestGsmSwapEdge is TestGhoBase {
       6 // decimals
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
-    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
-      address(gsm),
-      SHORT_EXECUTOR,
-      ''
-    );
-    gsm = Gsm(address(gsmProxy));
+    gsm = Gsm(address(new AdminUpgradeabilityProxy(address(gsm), SHORT_EXECUTOR, '')));
     gsm.initialize(ALICE, TREASURY, 1_000_000e6, address(GHO_RESERVE));
     GHO_RESERVE.addEntity(address(gsm));
     GHO_RESERVE.setLimit(address(gsm), 100_000_000 ether);
@@ -339,12 +309,7 @@ contract TestGsmSwapEdge is TestGhoBase {
       24 // decimals
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
-    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
-      address(gsm),
-      SHORT_EXECUTOR,
-      ''
-    );
-    gsm = Gsm(address(gsmProxy));
+    gsm = Gsm(address(new AdminUpgradeabilityProxy(address(gsm), SHORT_EXECUTOR, '')));
     gsm.initialize(ALICE, TREASURY, 1_000_000e24, address(GHO_RESERVE));
     GHO_RESERVE.addEntity(address(gsm));
     GHO_RESERVE.setLimit(address(gsm), 100_000_000 ether);
@@ -396,12 +361,7 @@ contract TestGsmSwapEdge is TestGhoBase {
       6 // decimals
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
-    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
-      address(gsm),
-      SHORT_EXECUTOR,
-      ''
-    );
-    gsm = Gsm(address(gsmProxy));
+    gsm = Gsm(address(new AdminUpgradeabilityProxy(address(gsm), SHORT_EXECUTOR, '')));
     gsm.initialize(ALICE, TREASURY, 1_000_000e6, address(GHO_RESERVE));
     GHO_RESERVE.addEntity(address(gsm));
     GHO_RESERVE.setLimit(address(gsm), 100_000_000 ether);
@@ -452,12 +412,7 @@ contract TestGsmSwapEdge is TestGhoBase {
       24 // decimals
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
-    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
-      address(gsm),
-      SHORT_EXECUTOR,
-      ''
-    );
-    gsm = Gsm(address(gsmProxy));
+    gsm = Gsm(address(new AdminUpgradeabilityProxy(address(gsm), SHORT_EXECUTOR, '')));
     gsm.initialize(ALICE, TREASURY, 1_000_000e24, address(GHO_RESERVE));
     GHO_RESERVE.addEntity(address(gsm));
     GHO_RESERVE.setLimit(address(gsm), 100_000_000 ether);

--- a/tests/unit/TestGsmSwapEdge.t.sol
+++ b/tests/unit/TestGsmSwapEdge.t.sol
@@ -19,6 +19,12 @@ contract TestGsmSwapEdge is TestGhoBase {
       5
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
+    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
+      address(gsm),
+      SHORT_EXECUTOR,
+      ''
+    );
+    gsm = Gsm(address(gsmProxy));
     gsm.initialize(address(this), TREASURY, type(uint128).max, address(GHO_RESERVE));
     GHO_RESERVE.addEntity(address(gsm));
     GHO_RESERVE.setLimit(address(gsm), type(uint128).max);
@@ -77,6 +83,12 @@ contract TestGsmSwapEdge is TestGhoBase {
       18
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
+    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
+      address(gsm),
+      SHORT_EXECUTOR,
+      ''
+    );
+    gsm = Gsm(address(gsmProxy));
     gsm.initialize(address(this), TREASURY, 100_000_000e18, address(GHO_RESERVE));
     gsm.updateFeeStrategy(address(newFeeStrategy));
     GHO_RESERVE.addEntity(address(gsm));
@@ -112,6 +124,12 @@ contract TestGsmSwapEdge is TestGhoBase {
       18
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
+    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
+      address(gsm),
+      SHORT_EXECUTOR,
+      ''
+    );
+    gsm = Gsm(address(gsmProxy));
     gsm.initialize(address(this), TREASURY, 100_000_000e18, address(GHO_RESERVE));
     gsm.updateFeeStrategy(address(newFeeStrategy));
     GHO_RESERVE.addEntity(address(gsm));
@@ -157,6 +175,12 @@ contract TestGsmSwapEdge is TestGhoBase {
       24 // decimals
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
+    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
+      address(gsm),
+      SHORT_EXECUTOR,
+      ''
+    );
+    gsm = Gsm(address(gsmProxy));
     gsm.initialize(ALICE, TREASURY, 1_000_000e24, address(GHO_RESERVE));
     GHO_RESERVE.addEntity(address(gsm));
     GHO_RESERVE.setLimit(address(gsm), 100_000_000 ether);
@@ -207,6 +231,12 @@ contract TestGsmSwapEdge is TestGhoBase {
       24 // decimals
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
+    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
+      address(gsm),
+      SHORT_EXECUTOR,
+      ''
+    );
+    gsm = Gsm(address(gsmProxy));
     gsm.initialize(ALICE, TREASURY, 1_000_000e24, address(GHO_RESERVE));
     GHO_RESERVE.addEntity(address(gsm));
     GHO_RESERVE.setLimit(address(gsm), 100_000_000 ether);
@@ -252,6 +282,12 @@ contract TestGsmSwapEdge is TestGhoBase {
       6 // decimals
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
+    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
+      address(gsm),
+      SHORT_EXECUTOR,
+      ''
+    );
+    gsm = Gsm(address(gsmProxy));
     gsm.initialize(ALICE, TREASURY, 1_000_000e6, address(GHO_RESERVE));
     GHO_RESERVE.addEntity(address(gsm));
     GHO_RESERVE.setLimit(address(gsm), 100_000_000 ether);
@@ -303,6 +339,12 @@ contract TestGsmSwapEdge is TestGhoBase {
       24 // decimals
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
+    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
+      address(gsm),
+      SHORT_EXECUTOR,
+      ''
+    );
+    gsm = Gsm(address(gsmProxy));
     gsm.initialize(ALICE, TREASURY, 1_000_000e24, address(GHO_RESERVE));
     GHO_RESERVE.addEntity(address(gsm));
     GHO_RESERVE.setLimit(address(gsm), 100_000_000 ether);
@@ -354,6 +396,12 @@ contract TestGsmSwapEdge is TestGhoBase {
       6 // decimals
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
+    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
+      address(gsm),
+      SHORT_EXECUTOR,
+      ''
+    );
+    gsm = Gsm(address(gsmProxy));
     gsm.initialize(ALICE, TREASURY, 1_000_000e6, address(GHO_RESERVE));
     GHO_RESERVE.addEntity(address(gsm));
     GHO_RESERVE.setLimit(address(gsm), 100_000_000 ether);
@@ -404,6 +452,12 @@ contract TestGsmSwapEdge is TestGhoBase {
       24 // decimals
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
+    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
+      address(gsm),
+      SHORT_EXECUTOR,
+      ''
+    );
+    gsm = Gsm(address(gsmProxy));
     gsm.initialize(ALICE, TREASURY, 1_000_000e24, address(GHO_RESERVE));
     GHO_RESERVE.addEntity(address(gsm));
     GHO_RESERVE.setLimit(address(gsm), 100_000_000 ether);

--- a/tests/unit/TestGsmSwapFuzz.t.sol
+++ b/tests/unit/TestGsmSwapFuzz.t.sol
@@ -89,12 +89,7 @@ contract TestGsmSwapFuzz is TestGhoBase {
       underlyingDecimals // decimals
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
-    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
-      address(gsm),
-      SHORT_EXECUTOR,
-      ''
-    );
-    gsm = Gsm(address(gsmProxy));
+    gsm = Gsm(address(new AdminUpgradeabilityProxy(address(gsm), SHORT_EXECUTOR, '')));
     gsm.initialize(address(this), TREASURY, type(uint128).max, address(GHO_RESERVE));
     GHO_RESERVE.addEntity(address(gsm));
     GHO_RESERVE.setLimit(address(gsm), type(uint128).max);
@@ -181,12 +176,7 @@ contract TestGsmSwapFuzz is TestGhoBase {
       underlyingDecimals // decimals
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
-    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
-      address(gsm),
-      SHORT_EXECUTOR,
-      ''
-    );
-    gsm = Gsm(address(gsmProxy));
+    gsm = Gsm(address(new AdminUpgradeabilityProxy(address(gsm), SHORT_EXECUTOR, '')));
     gsm.initialize(address(this), TREASURY, type(uint128).max, address(GHO_RESERVE));
 
     // Get gho amount for selling assets
@@ -224,12 +214,7 @@ contract TestGsmSwapFuzz is TestGhoBase {
       underlyingDecimals // decimals
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
-    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
-      address(gsm),
-      SHORT_EXECUTOR,
-      ''
-    );
-    gsm = Gsm(address(gsmProxy));
+    gsm = Gsm(address(new AdminUpgradeabilityProxy(address(gsm), SHORT_EXECUTOR, '')));
     gsm.initialize(address(this), TREASURY, type(uint128).max, address(GHO_RESERVE));
     GHO_TOKEN.addFacilitator(address(gsm), 'Test GSM', type(uint128).max);
 
@@ -271,12 +256,7 @@ contract TestGsmSwapFuzz is TestGhoBase {
       underlyingDecimals // decimals
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
-    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
-      address(gsm),
-      SHORT_EXECUTOR,
-      ''
-    );
-    gsm = Gsm(address(gsmProxy));
+    gsm = Gsm(address(new AdminUpgradeabilityProxy(address(gsm), SHORT_EXECUTOR, '')));
     gsm.initialize(address(this), TREASURY, type(uint128).max, address(GHO_RESERVE));
     GHO_RESERVE.addEntity(address(gsm));
     GHO_RESERVE.setLimit(address(gsm), type(uint128).max);
@@ -329,12 +309,7 @@ contract TestGsmSwapFuzz is TestGhoBase {
       underlyingDecimals // decimals
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
-    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
-      address(gsm),
-      SHORT_EXECUTOR,
-      ''
-    );
-    gsm = Gsm(address(gsmProxy));
+    gsm = Gsm(address(new AdminUpgradeabilityProxy(address(gsm), SHORT_EXECUTOR, '')));
     gsm.initialize(address(this), TREASURY, type(uint128).max, address(GHO_RESERVE));
     GHO_RESERVE.addEntity(address(gsm));
     GHO_RESERVE.setLimit(address(gsm), type(uint128).max);
@@ -380,12 +355,7 @@ contract TestGsmSwapFuzz is TestGhoBase {
       underlyingDecimals // decimals
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
-    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
-      address(gsm),
-      SHORT_EXECUTOR,
-      ''
-    );
-    gsm = Gsm(address(gsmProxy));
+    gsm = Gsm(address(new AdminUpgradeabilityProxy(address(gsm), SHORT_EXECUTOR, '')));
     gsm.initialize(address(this), TREASURY, type(uint128).max, address(GHO_RESERVE));
     GHO_RESERVE.addEntity(address(gsm));
     GHO_RESERVE.setLimit(address(gsm), type(uint128).max);
@@ -431,12 +401,7 @@ contract TestGsmSwapFuzz is TestGhoBase {
       underlyingDecimals // decimals
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
-    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
-      address(gsm),
-      SHORT_EXECUTOR,
-      ''
-    );
-    gsm = Gsm(address(gsmProxy));
+    gsm = Gsm(address(new AdminUpgradeabilityProxy(address(gsm), SHORT_EXECUTOR, '')));
     gsm.initialize(address(this), TREASURY, type(uint128).max, address(GHO_RESERVE));
     GHO_RESERVE.addEntity(address(gsm));
     GHO_RESERVE.setLimit(address(gsm), type(uint128).max);
@@ -483,12 +448,7 @@ contract TestGsmSwapFuzz is TestGhoBase {
       underlyingDecimals // decimals
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
-    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
-      address(gsm),
-      SHORT_EXECUTOR,
-      ''
-    );
-    gsm = Gsm(address(gsmProxy));
+    gsm = Gsm(address(new AdminUpgradeabilityProxy(address(gsm), SHORT_EXECUTOR, '')));
     gsm.initialize(address(this), TREASURY, type(uint128).max, address(GHO_RESERVE));
 
     if (buyFeeBps > 0 || sellFeeBps > 0) {
@@ -535,12 +495,7 @@ contract TestGsmSwapFuzz is TestGhoBase {
       underlyingDecimals // decimals
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
-    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
-      address(gsm),
-      SHORT_EXECUTOR,
-      ''
-    );
-    gsm = Gsm(address(gsmProxy));
+    gsm = Gsm(address(new AdminUpgradeabilityProxy(address(gsm), SHORT_EXECUTOR, '')));
     gsm.initialize(address(this), TREASURY, uint128(assetAmount), address(GHO_RESERVE));
 
     if (buyFeeBps > 0 || sellFeeBps > 0) {
@@ -612,12 +567,7 @@ contract TestGsmSwapFuzz is TestGhoBase {
       underlyingDecimals // decimals
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
-    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
-      address(gsm),
-      SHORT_EXECUTOR,
-      ''
-    );
-    gsm = Gsm(address(gsmProxy));
+    gsm = Gsm(address(new AdminUpgradeabilityProxy(address(gsm), SHORT_EXECUTOR, '')));
     gsm.initialize(address(this), TREASURY, uint128(assetAmount), address(GHO_RESERVE));
 
     if (buyFeeBps > 0 || sellFeeBps > 0) {
@@ -685,12 +635,7 @@ contract TestGsmSwapFuzz is TestGhoBase {
       underlyingDecimals // decimals
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
-    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
-      address(gsm),
-      SHORT_EXECUTOR,
-      ''
-    );
-    gsm = Gsm(address(gsmProxy));
+    gsm = Gsm(address(new AdminUpgradeabilityProxy(address(gsm), SHORT_EXECUTOR, '')));
     gsm.initialize(address(this), TREASURY, uint128(assetAmount), address(GHO_RESERVE));
     GHO_RESERVE.addEntity(address(gsm));
     GHO_RESERVE.setLimit(address(gsm), type(uint128).max);
@@ -790,12 +735,7 @@ contract TestGsmSwapFuzz is TestGhoBase {
       underlyingDecimals // decimals
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
-    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
-      address(gsm),
-      SHORT_EXECUTOR,
-      ''
-    );
-    gsm = Gsm(address(gsmProxy));
+    gsm = Gsm(address(new AdminUpgradeabilityProxy(address(gsm), SHORT_EXECUTOR, '')));
     gsm.initialize(address(this), TREASURY, type(uint128).max, address(GHO_RESERVE));
     GHO_RESERVE.addEntity(address(gsm));
     GHO_RESERVE.setLimit(address(gsm), type(uint128).max);

--- a/tests/unit/TestGsmSwapFuzz.t.sol
+++ b/tests/unit/TestGsmSwapFuzz.t.sol
@@ -89,6 +89,12 @@ contract TestGsmSwapFuzz is TestGhoBase {
       underlyingDecimals // decimals
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
+    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
+      address(gsm),
+      SHORT_EXECUTOR,
+      ''
+    );
+    gsm = Gsm(address(gsmProxy));
     gsm.initialize(address(this), TREASURY, type(uint128).max, address(GHO_RESERVE));
     GHO_RESERVE.addEntity(address(gsm));
     GHO_RESERVE.setLimit(address(gsm), type(uint128).max);
@@ -175,6 +181,12 @@ contract TestGsmSwapFuzz is TestGhoBase {
       underlyingDecimals // decimals
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
+    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
+      address(gsm),
+      SHORT_EXECUTOR,
+      ''
+    );
+    gsm = Gsm(address(gsmProxy));
     gsm.initialize(address(this), TREASURY, type(uint128).max, address(GHO_RESERVE));
 
     // Get gho amount for selling assets
@@ -212,6 +224,12 @@ contract TestGsmSwapFuzz is TestGhoBase {
       underlyingDecimals // decimals
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
+    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
+      address(gsm),
+      SHORT_EXECUTOR,
+      ''
+    );
+    gsm = Gsm(address(gsmProxy));
     gsm.initialize(address(this), TREASURY, type(uint128).max, address(GHO_RESERVE));
     GHO_TOKEN.addFacilitator(address(gsm), 'Test GSM', type(uint128).max);
 
@@ -253,6 +271,12 @@ contract TestGsmSwapFuzz is TestGhoBase {
       underlyingDecimals // decimals
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
+    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
+      address(gsm),
+      SHORT_EXECUTOR,
+      ''
+    );
+    gsm = Gsm(address(gsmProxy));
     gsm.initialize(address(this), TREASURY, type(uint128).max, address(GHO_RESERVE));
     GHO_RESERVE.addEntity(address(gsm));
     GHO_RESERVE.setLimit(address(gsm), type(uint128).max);
@@ -305,6 +329,12 @@ contract TestGsmSwapFuzz is TestGhoBase {
       underlyingDecimals // decimals
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
+    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
+      address(gsm),
+      SHORT_EXECUTOR,
+      ''
+    );
+    gsm = Gsm(address(gsmProxy));
     gsm.initialize(address(this), TREASURY, type(uint128).max, address(GHO_RESERVE));
     GHO_RESERVE.addEntity(address(gsm));
     GHO_RESERVE.setLimit(address(gsm), type(uint128).max);
@@ -350,6 +380,12 @@ contract TestGsmSwapFuzz is TestGhoBase {
       underlyingDecimals // decimals
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
+    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
+      address(gsm),
+      SHORT_EXECUTOR,
+      ''
+    );
+    gsm = Gsm(address(gsmProxy));
     gsm.initialize(address(this), TREASURY, type(uint128).max, address(GHO_RESERVE));
     GHO_RESERVE.addEntity(address(gsm));
     GHO_RESERVE.setLimit(address(gsm), type(uint128).max);
@@ -395,6 +431,12 @@ contract TestGsmSwapFuzz is TestGhoBase {
       underlyingDecimals // decimals
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
+    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
+      address(gsm),
+      SHORT_EXECUTOR,
+      ''
+    );
+    gsm = Gsm(address(gsmProxy));
     gsm.initialize(address(this), TREASURY, type(uint128).max, address(GHO_RESERVE));
     GHO_RESERVE.addEntity(address(gsm));
     GHO_RESERVE.setLimit(address(gsm), type(uint128).max);
@@ -441,6 +483,12 @@ contract TestGsmSwapFuzz is TestGhoBase {
       underlyingDecimals // decimals
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
+    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
+      address(gsm),
+      SHORT_EXECUTOR,
+      ''
+    );
+    gsm = Gsm(address(gsmProxy));
     gsm.initialize(address(this), TREASURY, type(uint128).max, address(GHO_RESERVE));
 
     if (buyFeeBps > 0 || sellFeeBps > 0) {
@@ -487,6 +535,12 @@ contract TestGsmSwapFuzz is TestGhoBase {
       underlyingDecimals // decimals
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
+    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
+      address(gsm),
+      SHORT_EXECUTOR,
+      ''
+    );
+    gsm = Gsm(address(gsmProxy));
     gsm.initialize(address(this), TREASURY, uint128(assetAmount), address(GHO_RESERVE));
 
     if (buyFeeBps > 0 || sellFeeBps > 0) {
@@ -558,6 +612,12 @@ contract TestGsmSwapFuzz is TestGhoBase {
       underlyingDecimals // decimals
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
+    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
+      address(gsm),
+      SHORT_EXECUTOR,
+      ''
+    );
+    gsm = Gsm(address(gsmProxy));
     gsm.initialize(address(this), TREASURY, uint128(assetAmount), address(GHO_RESERVE));
 
     if (buyFeeBps > 0 || sellFeeBps > 0) {
@@ -625,6 +685,12 @@ contract TestGsmSwapFuzz is TestGhoBase {
       underlyingDecimals // decimals
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
+    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
+      address(gsm),
+      SHORT_EXECUTOR,
+      ''
+    );
+    gsm = Gsm(address(gsmProxy));
     gsm.initialize(address(this), TREASURY, uint128(assetAmount), address(GHO_RESERVE));
     GHO_RESERVE.addEntity(address(gsm));
     GHO_RESERVE.setLimit(address(gsm), type(uint128).max);
@@ -724,6 +790,12 @@ contract TestGsmSwapFuzz is TestGhoBase {
       underlyingDecimals // decimals
     );
     Gsm gsm = new Gsm(address(GHO_TOKEN), address(newToken), address(newPriceStrategy));
+    AdminUpgradeabilityProxy gsmProxy = new AdminUpgradeabilityProxy(
+      address(gsm),
+      SHORT_EXECUTOR,
+      ''
+    );
+    gsm = Gsm(address(gsmProxy));
     gsm.initialize(address(this), TREASURY, type(uint128).max, address(GHO_RESERVE));
     GHO_RESERVE.addEntity(address(gsm));
     GHO_RESERVE.setLimit(address(gsm), type(uint128).max);


### PR DESCRIPTION
This PR adds the `initializer` modifier to the constructor of the Gsm contract so that the implementation contract of the Gsm is already initialized upon deployment. This will make deployments of the Gsm contract easier and safer.