### PR TITLE
Update sGhoSteward to fund sGHO

### DIFF
--- a/docs/sGhoSteward.md
+++ b/docs/sGhoSteward.md
@@ -9,7 +9,7 @@ It provides role-based access-controlled mechanisms to safely adjust the `target
 
 - Allows updating of `targetRate` and `supplyCap` of `sGHO` through this contract.
 - Allows funding `sGHO` yield by transfering `GHO` from the Aave Collector, optionally pre-withdrawing `GHO` from the `AaveV3EthereumLido` pool first.
-- Bounds each funding transfer by a governance-configurable `maxTransferAmount`, and rate-limits consecutive transfers via a `MINIMUM_DELAY` debounce (2 days).
+- Bounds each funding transfer by a governance-configurable `maxTransferAmount`, and rate-limits consecutive transfers via a `MINIMUM_DELAY` debounce (1 day).
 - Implements the `targetRate` formula as a composition of three parameters (with `AMPLIFICATION_DENOMINATOR` fixed at 100_00):
 
   `targetRate = AmplificationFactor / AMPLIFICATION_DENOMINATOR * FloatRate + FixedRate`

--- a/docs/sGhoSteward.md
+++ b/docs/sGhoSteward.md
@@ -8,6 +8,7 @@ It provides role-based access-controlled mechanisms to safely adjust the `target
 ## Key features
 
 - Allows updating of `targetRate` and `supplyCap` of `sGHO` through this contract.
+- Allows funding `sGHO` yield by transfering `GHO` from the Aave Collector.
 - Implements the `targetRate` formula as a composition of three parameters (with `AMPLIFICATION_DENOMINATOR` fixed at 100_00):
 
   `targetRate = AmplificationFactor / AMPLIFICATION_DENOMINATOR * FloatRate + FixedRate`
@@ -21,16 +22,17 @@ It provides role-based access-controlled mechanisms to safely adjust the `target
 
 The `DEFAULT_ADMIN_ROLE` is set exclusively for governance initially, which has full authority to delegate, assign, or revoke roles for specific addresses.
 
-In addition to the admin role, there are four specialized manager roles:
+In addition to the admin role, there are five specialized manager roles:
 
-| Role                       | Description                                    |
-| :------------------------- | :--------------------------------------------- |
-| AMPLIFICATION_MANAGER_ROLE | Authorized to update the Amplification Factor. |
-| FLOAT_RATE_MANAGER_ROLE    | Authorized to update the Float Rate.           |
-| FIXED_RATE_MANAGER_ROLE    | Authorized to update the Fixed Rate.           |
-| SUPPLY_CAP_MANAGER_ROLE    | Authorized to update the Supply Cap.           |
+| Role                       | Description                                        |
+| :------------------------- | :------------------------------------------------- |
+| AMPLIFICATION_MANAGER_ROLE | Authorized to update the Amplification Factor.     |
+| FLOAT_RATE_MANAGER_ROLE    | Authorized to update the Float Rate.               |
+| FIXED_RATE_MANAGER_ROLE    | Authorized to update the Fixed Rate.               |
+| SUPPLY_CAP_MANAGER_ROLE    | Authorized to update the Supply Cap.               |
+| SGHO_FUNDING_ROLE          | Authorized to transfer GHO from collector to sGHO. |
 
-Initially, the four roles mentioned above (rate config) are assigned to the `riskCouncil`, a 3-of-4 multisig composed of service providers.
+Initially, the five roles mentioned above (rate config, funding) are assigned to the `riskCouncil`, a 3-of-4 multisig composed of service providers.
 Over time, **Aave DAO** may choose to delegate or reassign these roles to other addresses as it deems appropriate - for example, allowing oracles to control certain components while councils or other entities manage others.
 
 ## Target Rate Configuration

--- a/docs/sGhoSteward.md
+++ b/docs/sGhoSteward.md
@@ -8,7 +8,8 @@ It provides role-based access-controlled mechanisms to safely adjust the `target
 ## Key features
 
 - Allows updating of `targetRate` and `supplyCap` of `sGHO` through this contract.
-- Allows funding `sGHO` yield by transfering `GHO` from the Aave Collector.
+- Allows funding `sGHO` yield by transfering `GHO` from the Aave Collector, optionally pre-withdrawing `GHO` from the `AaveV3EthereumLido` pool first.
+- Bounds each funding transfer by a governance-configurable `maxTransferAmount`, and rate-limits consecutive transfers via a `MINIMUM_DELAY` debounce (2 days).
 - Implements the `targetRate` formula as a composition of three parameters (with `AMPLIFICATION_DENOMINATOR` fixed at 100_00):
 
   `targetRate = AmplificationFactor / AMPLIFICATION_DENOMINATOR * FloatRate + FixedRate`
@@ -116,13 +117,43 @@ The `setSupplyCap()` function allows authorized users to update the `sGHO` `supp
 - The maximum cap allowed within sGHO is `uint160` (less than the `uint256` input type of this function). Any attempt to set a value above this threshold results in a revert.
 - Similarly, attempting to set the same value as the current `supplyCap` will also cause the transaction to revert.
 
+## Funding sGHO
+
+The `fundSGho(uint256 amount, bool withdrawFromAave)` function transfers `GHO` from the Aave Collector into `sGHO` to seed yield.
+
+Behavior:
+
+- Only callable by addresses holding `SGHO_FUNDING_ROLE`.
+- The steward contract must have been granted `FUNDS_ADMIN_ROLE` on the Collector, otherwise the `COLLECTOR.transfer(...)` call reverts with `OnlyFundsAdmin`.
+- `amount` must be non-zero (`ZeroAmount` revert otherwise) and must be less than or equal to `maxTransferAmount` (`MaxTransferExceeded(maxTransferAmount)` revert otherwise).
+- Successive calls are rate-limited: at least `MINIMUM_DELAY` (2 days) must elapse between calls. A call inside the window reverts with `DebounceNotRespected`. The internal `_transferDebounce` timestamp is updated to `block.timestamp` once the input checks pass, so the window is anchored to the most recent attempt that reached the transfer.
+- If `withdrawFromAave` is `false`, the steward simply transfers `amount` of `GHO` from the Collector to `sGHO`. The Collector must hold sufficient `GHO`, otherwise the underlying `ERC20.transfer` reverts.
+- If `withdrawFromAave` is `true`, the steward first pulls `amount` of `aEthLidoGHO` (the `AaveV3EthereumLido` `GHO` aToken — referred to in the contract as `PRIME_GHO`) from the Collector to itself, then calls `POOL.withdraw(GHO, amount, COLLECTOR)` to redeem the underlying `GHO` straight back into the Collector. The final `COLLECTOR.transfer(GHO, sGHO, amount)` then forwards the freshly-withdrawn `GHO` to `sGHO`. The Collector must hold sufficient `aEthLidoGHO` for this branch to succeed.
+- Emits `SGhoFunded(amount)` on success.
+
+### Max Transfer Amount Management
+
+`maxTransferAmount` caps the per-call size of `fundSGho`. It defaults to `0` (so funding is effectively disabled until governance opens it) and is updated via:
+
+```solidity
+function setMaxTransferAmount(uint256 maxAmount) external; // DEFAULT_ADMIN_ROLE
+```
+
+- Only callable by the `DEFAULT_ADMIN_ROLE` (governance). This is deliberately separate from `SGHO_FUNDING_ROLE` so the risk council can fund within a ceiling that only governance can move.
+- Reverts with `MaxTransferAmountUnchanged` if the new value equals the current one.
+- Emits `MaxTransferAmountUpdated(caller, maxAmount)` on success.
+
 ## Contract Summary
 
-| Function                               | Description                                        | Required Role               |
-| :------------------------------------- | :------------------------------------------------- | :-------------------------- |
-| `setRateConfig(RateConfig newConfig)`  | Updates amplification, float, and fixed rates      | Corresponding Manager Roles |
-| `setSupplyCap(uint256 newSupplyCap)`   | Updates the maximum allowed sGHO supply            | `SUPPLY_CAP_MANAGER_ROLE`   |
-| `getRateConfig()`                      | Returns the current rate configuration             | Public                      |
-| `previewTargetRate(RateConfig config)` | Computes the target rate for a given configuration | Public                      |
-| `sGHO()`                               | Returns current `sGHO` address                     | Public                      |
-| `MAX_RATE()`                           | Returns max available `targetRate` that can be set | Public                      |
+| Function                                          | Description                                                                                   | Required Role               |
+| :------------------------------------------------ | :-------------------------------------------------------------------------------------------- | :-------------------------- |
+| `setRateConfig(RateConfig newConfig)`             | Updates amplification, float, and fixed rates                                                 | Corresponding Manager Roles |
+| `setSupplyCap(uint256 newSupplyCap)`              | Updates the maximum allowed sGHO supply                                                       | `SUPPLY_CAP_MANAGER_ROLE`   |
+| `fundSGho(uint256 amount, bool withdrawFromAave)` | Transfers GHO from the Collector to sGHO; optionally redeeming from the Aave Prime pool first | `SGHO_FUNDING_ROLE`         |
+| `setMaxTransferAmount(uint256 maxAmount)`         | Updates the per-call cap on `fundSGho`                                                        | `DEFAULT_ADMIN_ROLE`        |
+| `getRateConfig()`                                 | Returns the current rate configuration                                                        | Public                      |
+| `previewTargetRate(RateConfig config)`            | Computes the target rate for a given configuration                                            | Public                      |
+| `sGHO()`                                          | Returns current `sGHO` address                                                                | Public                      |
+| `MAX_RATE()`                                      | Returns max available `targetRate` that can be set                                            | Public                      |
+| `MINIMUM_DELAY()`                                 | Returns the debounce window (in seconds) between `fundSGho` calls                             | Public                      |
+| `maxTransferAmount()`                             | Returns the current per-call cap on `fundSGho`                                                | Public                      |

--- a/src/contracts/misc/interfaces/IsGhoSteward.sol
+++ b/src/contracts/misc/interfaces/IsGhoSteward.sol
@@ -128,11 +128,6 @@ interface IsGhoSteward {
   function sGHO() external view returns (IsGho);
 
   /**
-   * @notice Returns `COLLECTOR` address, wrapped in interface.
-   */
-  function COLLECTOR() external view returns (ICollector);
-
-  /**
    * @notice Returns the max `targetRate` that can be set.
    */
   function MAX_RATE() external view returns (uint16);

--- a/src/contracts/misc/interfaces/IsGhoSteward.sol
+++ b/src/contracts/misc/interfaces/IsGhoSteward.sol
@@ -54,6 +54,13 @@ interface IsGhoSteward {
   event SupplyCapUpdated(address indexed caller, uint256 supplyCap);
 
   /**
+   * @dev Event is emitted whenever `maxTransferAmount` is updated.
+   * @param caller Message sender, who initiated the update
+   * @param maxTransferAmount New maximum transfer amount
+   */
+  event MaxTransferAmountUpdated(address indexed caller, uint256 maxTransferAmount);
+
+  /**
    * @dev Attempted to set zero address.
    */
   error ZeroAddress();
@@ -64,9 +71,20 @@ interface IsGhoSteward {
   error ZeroAmount();
 
   /**
+   * @dev Attempted to transfer before minimum timelock delay has passed.
+   */
+  error DebounceNotRespected();
+
+  /**
    * @dev Attempted to set rate greater than `MAX_RATE` defined in `sGHO`.
    */
   error MaxRateExceeded();
+
+  /**
+   * @dev Attempted to transfer `GHO` amount greater than maximum allowed transfer.
+   * @param maxTransfer The maximum amount of `GHO` that can be transferred
+   */
+  error MaxTransferExceeded(uint256 maxTransfer);
 
   /**
    * @dev Attempted to set the same rate, which is already set.
@@ -77,6 +95,11 @@ interface IsGhoSteward {
    * @dev Attempted to set the same supplyCap, which is already set.
    */
   error SupplyCapUnchanged();
+
+  /**
+   * @dev Attempted to set the same `maxTransferAmount`, which is already set.
+   */
+  error MaxTransferAmountUnchanged();
 
   /**
    * @notice Updates `targetRate` on `sGHO` and `rateConfig` inside the steward using new values.
@@ -108,12 +131,23 @@ interface IsGhoSteward {
 
   /**
    * @notice Sends specified amount of `GHO` token to `sGHO`.
-   * @dev Specified amount must be held in the collector or will revert.
+   * @dev Specified amount must be held in the collector or will revert, unless
+   * withdrawFromAave is true. In that case, `GHO` will first be withdrawn from
+   * `AaveV3EthereumLido` pool to then be transfered. Specified amount of `aEthLidoGHO`
+   * must be held in the collector in that scenario or will revert.
    * Only callable by `SGHO_FUNDING_ROLE`.
    * This contract must be granted `FUNDS_ADMIN_ROLE` from the collector.
    * @param amount Amount of GHO token to send.
+   * @param withdrawFromAave Whether to withdraw `GHO` from Aave Pool
    */
-  function fundSGho(uint256 amount) external;
+  function fundSGho(uint256 amount, bool withdrawFromAave) external;
+
+  /**
+   * @notice Updates the maximum amount of `GHO` that can be transferred in a single `fundSGho` call.
+   * @dev Only callable by `DEFAULT_ADMIN_ROLE`. Reverts if the new value equals the current one.
+   * @param maxAmount New maximum transfer amount (in wei)
+   */
+  function setMaxTransferAmount(uint256 maxAmount) external;
 
   /**
    * @notice Calculates `targetRate` using `rateConfig_` struct.
@@ -167,4 +201,16 @@ interface IsGhoSteward {
    * @notice Returns role that can send `GHO` from collector to `sGHO`.
    */
   function SGHO_FUNDING_ROLE() external view returns (bytes32);
+
+  /**
+   * @notice Returns the minimum delay that must be respected between parameters update.
+   * @return The minimum delay between parameter updates (in seconds)
+   */
+  function MINIMUM_DELAY() external view returns (uint256);
+
+  /**
+   * @notice Returns the maximum amount that can be transfered at a time between timelocks.
+   * @return The maximum amount that can be transfered (in wei)
+   */
+  function maxTransferAmount() external view returns (uint256);
 }

--- a/src/contracts/misc/interfaces/IsGhoSteward.sol
+++ b/src/contracts/misc/interfaces/IsGhoSteward.sol
@@ -59,6 +59,11 @@ interface IsGhoSteward {
   error ZeroAddress();
 
   /**
+   * @dev Attempted to transfer zero amount.
+   */
+  error ZeroAmount();
+
+  /**
    * @dev Attempted to set rate greater than `MAX_RATE` defined in `sGHO`.
    */
   error MaxRateExceeded();
@@ -105,6 +110,7 @@ interface IsGhoSteward {
    * @notice Sends specified amount of `GHO` token to `sGHO`.
    * @dev Specified amount must be held in the collector or will revert.
    * Only callable by `SGHO_FUNDING_ROLE`.
+   * This contract must be granted `FUNDS_ADMIN_ROLE` from the collector.
    * @param amount Amount of GHO token to send.
    */
   function fundSGho(uint256 amount) external;

--- a/src/contracts/misc/interfaces/IsGhoSteward.sol
+++ b/src/contracts/misc/interfaces/IsGhoSteward.sol
@@ -212,5 +212,5 @@ interface IsGhoSteward {
    * @notice Returns the maximum amount that can be transfered at a time between timelocks.
    * @return The maximum amount that can be transfered (in wei)
    */
-  function maxTransferAmount() external view returns (uint256);
+  function getMaxTransferAmount() external view returns (uint256);
 }

--- a/src/contracts/misc/interfaces/IsGhoSteward.sol
+++ b/src/contracts/misc/interfaces/IsGhoSteward.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import {ICollector} from 'aave-v3-origin/contracts/treasury/ICollector.sol';
 import {IsGho} from '../../sgho/interfaces/IsGho.sol';
 
 /**
@@ -38,6 +39,12 @@ interface IsGhoSteward {
     uint16 floatRate,
     uint16 fixedRate
   );
+
+  /**
+   * @dev Event is emitted whenever `GHO` token is sent to `sGHO`.
+   * @param amount Amount of `GHO` sent to `sGHO`.
+   */
+  event SGhoFunded(uint256 amount);
 
   /**
    * @dev Event is emitted whenever the `supplyCap` is updated.
@@ -95,6 +102,14 @@ interface IsGhoSteward {
   function setSupplyCap(uint256 supplyCap_) external;
 
   /**
+   * @notice Sends specified amount of `GHO` token to `sGHO`.
+   * @dev Specified amount must be held in the collector or will revert.
+   * Only callable by `SGHO_FUNDING_ROLE`.
+   * @param amount Amount of GHO token to send.
+   */
+  function fundSGho(uint256 amount) external;
+
+  /**
    * @notice Calculates `targetRate` using `rateConfig_` struct.
    * @dev Reverts if new `targetRate` exceeds `MAX_RATE`.
    * @param rateConfig_ Set of parameters for calculating `targetRate`
@@ -111,6 +126,11 @@ interface IsGhoSteward {
    * @notice Returns `sGHO` address, wrapped in interface.
    */
   function sGHO() external view returns (IsGho);
+
+  /**
+   * @notice Returns `COLLECTOR` address, wrapped in interface.
+   */
+  function COLLECTOR() external view returns (ICollector);
 
   /**
    * @notice Returns the max `targetRate` that can be set.
@@ -141,4 +161,9 @@ interface IsGhoSteward {
    * @notice Returns role that can update the `supplyCap` parameter.
    */
   function SUPPLY_CAP_MANAGER_ROLE() external view returns (bytes32);
+
+  /**
+   * @notice Returns role that can send `GHO` from collector to `sGHO`.
+   */
+  function SGHO_FUNDING_ROLE() external view returns (bytes32);
 }

--- a/src/contracts/misc/sGhoSteward.sol
+++ b/src/contracts/misc/sGhoSteward.sol
@@ -38,7 +38,7 @@ contract sGhoSteward is AccessControl, IsGhoSteward {
   uint16 public immutable MAX_RATE;
 
   /// @notice sGho contract address
-  IsGho internal immutable _sGho;
+  IsGho internal immutable SGHO;
 
   ICollector internal immutable COLLECTOR;
 
@@ -57,10 +57,10 @@ contract sGhoSteward is AccessControl, IsGhoSteward {
       revert ZeroAddress();
     }
 
-    _sGho = IsGho(sGho);
-    MAX_RATE = _sGho.MAX_SAFE_RATE();
+    SGHO = IsGho(sGho);
+    MAX_RATE = SGHO.MAX_SAFE_RATE();
     COLLECTOR = ICollector(collector);
-    GHO = IERC20(_sGho.GHO());
+    GHO = IERC20(SGHO.GHO());
 
     _grantRole(DEFAULT_ADMIN_ROLE, owner);
 
@@ -107,19 +107,21 @@ contract sGhoSteward is AccessControl, IsGhoSteward {
 
   /// @inheritdoc IsGhoSteward
   function setSupplyCap(uint256 supplyCap) external onlyRole(SUPPLY_CAP_MANAGER_ROLE) {
-    uint256 currentSupplyCap = _sGho.supplyCap();
+    uint256 currentSupplyCap = SGHO.supplyCap();
 
     if (currentSupplyCap == supplyCap) {
       revert SupplyCapUnchanged();
     }
 
-    _sGho.setSupplyCap(supplyCap.toUint160());
+    SGHO.setSupplyCap(supplyCap.toUint160());
     emit SupplyCapUpdated(msg.sender, supplyCap);
   }
 
   /// @inheritdoc IsGhoSteward
   function fundSGho(uint256 amount) external onlyRole(SGHO_FUNDING_ROLE) {
-    COLLECTOR.transfer(GHO, address(_sGho), amount);
+    if (amount == 0) revert ZeroAmount();
+    
+    COLLECTOR.transfer(GHO, address(SGHO), amount);
     emit SGhoFunded(amount);
   }
 
@@ -135,13 +137,13 @@ contract sGhoSteward is AccessControl, IsGhoSteward {
 
   /// @inheritdoc IsGhoSteward
   function sGHO() external view returns (IsGho) {
-    return _sGho;
+    return SGHO;
   }
 
   function _setRateConfig(RateConfig memory rateConfig) internal returns (uint16) {
     uint16 targetRate = _computeRateConfig(rateConfig);
 
-    _sGho.setTargetRate(targetRate);
+    SGHO.setTargetRate(targetRate);
     _rateConfig = rateConfig;
 
     emit RateConfigUpdated(

--- a/src/contracts/misc/sGhoSteward.sol
+++ b/src/contracts/misc/sGhoSteward.sol
@@ -2,9 +2,10 @@
 pragma solidity ^0.8.10;
 
 import {IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/IERC20.sol';
+import {ICollector} from 'aave-v3-origin/contracts/treasury/ICollector.sol';
+import {IPool} from 'aave-v3-origin/contracts/interfaces/IPool.sol';
 import {AccessControl} from 'src/contracts/dependencies/openzeppelin-contracts/contracts/access/AccessControl.sol';
 import {SafeCast} from 'src/contracts/dependencies/openzeppelin-contracts/contracts/utils/math/SafeCast.sol';
-import {ICollector} from 'aave-v3-origin/contracts/treasury/ICollector.sol';
 import {IsGho} from 'src/contracts/sgho/interfaces/IsGho.sol';
 import {IsGhoSteward} from 'src/contracts/misc/interfaces/IsGhoSteward.sol';
 
@@ -15,6 +16,9 @@ import {IsGhoSteward} from 'src/contracts/misc/interfaces/IsGhoSteward.sol';
  */
 contract sGhoSteward is AccessControl, IsGhoSteward {
   using SafeCast for uint256;
+
+  /// @inheritdoc IsGhoSteward
+  uint256 public constant MINIMUM_DELAY = 2 days;
 
   /// @inheritdoc IsGhoSteward
   uint16 public constant AMPLIFICATION_DENOMINATOR = 100_00;
@@ -40,19 +44,42 @@ contract sGhoSteward is AccessControl, IsGhoSteward {
   /// @notice sGho contract address
   IsGho internal immutable SGHO;
 
+  /// @notice sGho contract address
   ICollector internal immutable COLLECTOR;
 
+  /// @notice Gho contract address
   IERC20 internal immutable GHO;
+
+  /// @notice aEthLidoGho contract address
+  IERC20 internal immutable PRIME_GHO;
+
+  /// @notice Aave V3 Prime pool contract address
+  IPool internal immutable POOL;
 
   /// @notice Current rate parameters
   RateConfig internal _rateConfig;
 
-  constructor(address owner, address riskCouncil, address sGho, address collector) {
+  /// @notice Last transfer made by the steward
+  uint256 internal _transferDebounce;
+
+  /// @inheritdoc IsGhoSteward
+  uint256 public maxTransferAmount;
+
+  constructor(
+    address owner,
+    address riskCouncil,
+    address sGho,
+    address primeGho,
+    address collector,
+    address pool
+  ) {
     if (
       owner == address(0) ||
       riskCouncil == address(0) ||
       sGho == address(0) ||
-      collector == address(0)
+      primeGho == address(0) ||
+      collector == address(0) ||
+      pool == address(0)
     ) {
       revert ZeroAddress();
     }
@@ -61,6 +88,8 @@ contract sGhoSteward is AccessControl, IsGhoSteward {
     MAX_RATE = SGHO.MAX_SAFE_RATE();
     COLLECTOR = ICollector(collector);
     GHO = IERC20(SGHO.GHO());
+    PRIME_GHO = IERC20(primeGho);
+    POOL = IPool(pool);
 
     _grantRole(DEFAULT_ADMIN_ROLE, owner);
 
@@ -118,11 +147,28 @@ contract sGhoSteward is AccessControl, IsGhoSteward {
   }
 
   /// @inheritdoc IsGhoSteward
-  function fundSGho(uint256 amount) external onlyRole(SGHO_FUNDING_ROLE) {
+  function fundSGho(uint256 amount, bool withdrawFromAave) external onlyRole(SGHO_FUNDING_ROLE) {
+    if (block.timestamp - _transferDebounce < MINIMUM_DELAY) revert DebounceNotRespected();
     if (amount == 0) revert ZeroAmount();
-    
+    if (amount > maxTransferAmount) revert MaxTransferExceeded(maxTransferAmount);
+
+    _transferDebounce = block.timestamp;
+
+    if (withdrawFromAave) {
+      COLLECTOR.transfer(PRIME_GHO, address(this), amount);
+      POOL.withdraw(address(GHO), amount, address(COLLECTOR));
+    }
+
     COLLECTOR.transfer(GHO, address(SGHO), amount);
     emit SGhoFunded(amount);
+  }
+
+  /// @inheritdoc IsGhoSteward
+  function setMaxTransferAmount(uint256 maxAmount) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    if (maxTransferAmount == maxAmount) revert MaxTransferAmountUnchanged();
+
+    maxTransferAmount = maxAmount;
+    emit MaxTransferAmountUpdated(msg.sender, maxAmount);
   }
 
   /// @inheritdoc IsGhoSteward

--- a/src/contracts/misc/sGhoSteward.sol
+++ b/src/contracts/misc/sGhoSteward.sol
@@ -58,6 +58,7 @@ contract sGhoSteward is AccessControl, IsGhoSteward {
     GHO = IERC20(gho);
 
     _grantRole(DEFAULT_ADMIN_ROLE, riskCouncil);
+    _grantRole(SGHO_FUNDING_ROLE, riskCouncil);
 
     // Initially all roles except `DEFAULT_ADMIN_ROLE` will be granted to the `owner`
     _grantRole(AMPLIFICATION_MANAGER_ROLE, owner);

--- a/src/contracts/misc/sGhoSteward.sol
+++ b/src/contracts/misc/sGhoSteward.sol
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.10;
 
+import {IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/IERC20.sol';
 import {AccessControl} from 'src/contracts/dependencies/openzeppelin-contracts/contracts/access/AccessControl.sol';
 import {SafeCast} from 'src/contracts/dependencies/openzeppelin-contracts/contracts/utils/math/SafeCast.sol';
+import {ICollector} from 'aave-v3-origin/contracts/treasury/ICollector.sol';
 import {IsGho} from 'src/contracts/sgho/interfaces/IsGho.sol';
 import {IsGhoSteward} from 'src/contracts/misc/interfaces/IsGhoSteward.sol';
 
@@ -30,21 +32,30 @@ contract sGhoSteward is AccessControl, IsGhoSteward {
   bytes32 public constant SUPPLY_CAP_MANAGER_ROLE = keccak256('SUPPLY_CAP_MANAGER_ROLE');
 
   /// @inheritdoc IsGhoSteward
+  bytes32 public constant SGHO_FUNDING_ROLE = keccak256('SGHO_FUNDING_ROLE');
+
+  /// @inheritdoc IsGhoSteward
   uint16 public immutable MAX_RATE;
 
   /// @notice sGho contract address
   IsGho internal immutable _sGho;
 
+  ICollector internal immutable COLLECTOR;
+
+  IERC20 internal immutable GHO;
+
   /// @notice Current rate parameters
   RateConfig internal _rateConfig;
 
-  constructor(address owner, address riskCouncil, address sGho) {
-    if (owner == address(0) || riskCouncil == address(0) || sGho == address(0)) {
+  constructor(address owner, address riskCouncil, address sGho, address gho, address collector) {
+    if (owner == address(0) || riskCouncil == address(0) || sGho == address(0) || collector == address(0)) {
       revert ZeroAddress();
     }
 
     _sGho = IsGho(sGho);
     MAX_RATE = _sGho.MAX_SAFE_RATE();
+    COLLECTOR = ICollector(collector);
+    GHO = IERC20(gho);
 
     _grantRole(DEFAULT_ADMIN_ROLE, riskCouncil);
 
@@ -98,6 +109,12 @@ contract sGhoSteward is AccessControl, IsGhoSteward {
 
     _sGho.setSupplyCap(supplyCap.toUint160());
     emit SupplyCapUpdated(msg.sender, supplyCap);
+  }
+
+  /// @inheritdoc IsGhoSteward
+  function fundSGho(uint256 amount) external onlyRole(SGHO_FUNDING_ROLE) {
+    COLLECTOR.transfer(GHO, address(_sGho), amount);
+    emit SGhoFunded(amount);
   }
 
   /// @inheritdoc IsGhoSteward

--- a/src/contracts/misc/sGhoSteward.sol
+++ b/src/contracts/misc/sGhoSteward.sol
@@ -18,7 +18,7 @@ contract sGhoSteward is AccessControl, IsGhoSteward {
   using SafeCast for uint256;
 
   /// @inheritdoc IsGhoSteward
-  uint256 public constant MINIMUM_DELAY = 2 days;
+  uint256 public constant MINIMUM_DELAY = 1 days;
 
   /// @inheritdoc IsGhoSteward
   uint16 public constant AMPLIFICATION_DENOMINATOR = 100_00;
@@ -60,10 +60,10 @@ contract sGhoSteward is AccessControl, IsGhoSteward {
   RateConfig internal _rateConfig;
 
   /// @notice Last transfer made by the steward
-  uint256 internal _transferDebounce;
+  uint256 internal _lastTransferTimestamp;
 
-  /// @inheritdoc IsGhoSteward
-  uint256 public maxTransferAmount;
+  /// @notice The maximum amount that can be transfered at a time between timelocks.
+  uint256 internal _maxTransferAmount = 100_000 ether;
 
   constructor(
     address owner,
@@ -148,11 +148,11 @@ contract sGhoSteward is AccessControl, IsGhoSteward {
 
   /// @inheritdoc IsGhoSteward
   function fundSGho(uint256 amount, bool withdrawFromAave) external onlyRole(SGHO_FUNDING_ROLE) {
-    if (block.timestamp - _transferDebounce < MINIMUM_DELAY) revert DebounceNotRespected();
+    if (block.timestamp - _lastTransferTimestamp < MINIMUM_DELAY) revert DebounceNotRespected();
     if (amount == 0) revert ZeroAmount();
-    if (amount > maxTransferAmount) revert MaxTransferExceeded(maxTransferAmount);
+    if (amount > _maxTransferAmount) revert MaxTransferExceeded(_maxTransferAmount);
 
-    _transferDebounce = block.timestamp;
+    _lastTransferTimestamp = block.timestamp;
 
     if (withdrawFromAave) {
       COLLECTOR.transfer(PRIME_GHO, address(this), amount);
@@ -165,9 +165,9 @@ contract sGhoSteward is AccessControl, IsGhoSteward {
 
   /// @inheritdoc IsGhoSteward
   function setMaxTransferAmount(uint256 maxAmount) external onlyRole(DEFAULT_ADMIN_ROLE) {
-    if (maxTransferAmount == maxAmount) revert MaxTransferAmountUnchanged();
+    if (_maxTransferAmount == maxAmount) revert MaxTransferAmountUnchanged();
 
-    maxTransferAmount = maxAmount;
+    _maxTransferAmount = maxAmount;
     emit MaxTransferAmountUpdated(msg.sender, maxAmount);
   }
 
@@ -184,6 +184,11 @@ contract sGhoSteward is AccessControl, IsGhoSteward {
   /// @inheritdoc IsGhoSteward
   function sGHO() external view returns (IsGho) {
     return SGHO;
+  }
+
+  /// @inheritdoc IsGhoSteward
+  function getMaxTransferAmount() external view returns (uint256) {
+    return _maxTransferAmount;
   }
 
   function _setRateConfig(RateConfig memory rateConfig) internal returns (uint16) {

--- a/src/contracts/misc/sGhoSteward.sol
+++ b/src/contracts/misc/sGhoSteward.sol
@@ -47,12 +47,11 @@ contract sGhoSteward is AccessControl, IsGhoSteward {
   /// @notice Current rate parameters
   RateConfig internal _rateConfig;
 
-  constructor(address owner, address riskCouncil, address sGho, address gho, address collector) {
+  constructor(address owner, address riskCouncil, address sGho, address collector) {
     if (
       owner == address(0) ||
       riskCouncil == address(0) ||
       sGho == address(0) ||
-      gho == address(0) ||
       collector == address(0)
     ) {
       revert ZeroAddress();
@@ -61,7 +60,7 @@ contract sGhoSteward is AccessControl, IsGhoSteward {
     _sGho = IsGho(sGho);
     MAX_RATE = _sGho.MAX_SAFE_RATE();
     COLLECTOR = ICollector(collector);
-    GHO = IERC20(gho);
+    GHO = IERC20(_sGho.GHO());
 
     _grantRole(DEFAULT_ADMIN_ROLE, owner);
 

--- a/tests/misc/sGhoSteward.t.sol
+++ b/tests/misc/sGhoSteward.t.sol
@@ -15,6 +15,7 @@ contract sGhoStewardTest is TestSGhoBase {
 
   address public riskCouncil = makeAddr('riskCouncil');
   address public ghoCommittee = makeAddr('ghoCommittee');
+  address public collector = makeAddr('collector');
 
   bytes32 public constant YIELD_MANAGER_ROLE = 'YIELD_MANAGER';
 
@@ -24,11 +25,12 @@ contract sGhoStewardTest is TestSGhoBase {
   bytes32 public constant FLOAT_RATE_MANAGER_ROLE = keccak256('FLOAT_RATE_MANAGER_ROLE');
   bytes32 public constant FIXED_RATE_MANAGER_ROLE = keccak256('FIXED_RATE_MANAGER_ROLE');
   bytes32 public constant SUPPLY_CAP_MANAGER_ROLE = keccak256('SUPPLY_CAP_MANAGER_ROLE');
+  bytes32 public constant SGHO_FUNDING_ROLE = keccak256('SGHO_FUNDING_ROLE');
 
   function setUp() public override {
     super.setUp();
 
-    steward = new sGhoSteward(ghoCommittee, riskCouncil, address(sgho));
+    steward = new sGhoSteward(ghoCommittee, riskCouncil, address(sgho), collector);
     sgho.grantRole(sgho.YIELD_MANAGER_ROLE(), address(steward));
   }
 
@@ -41,11 +43,16 @@ contract sGhoStewardTest is TestSGhoBase {
 
     vm.expectRevert(abi.encodeWithSelector(IsGhoSteward.ZeroAddress.selector));
     new sGhoSteward(ghoCommittee, riskCouncil, address(0));
+
+    vm.expectRevert(abi.encodeWithSelector(IsGhoSteward.ZeroAddress.selector));
+    new sGhoSteward(ghoCommittee, riskCouncil, address(sgho), address(0));
   }
 
   function test_initial() public view {
     assertTrue(steward.hasRole(DEFAULT_ADMIN_ROLE, riskCouncil));
     assertFalse(steward.hasRole(DEFAULT_ADMIN_ROLE, ghoCommittee));
+
+    assertTrue(steward.hasRole(SGHO_FUNDING_ROLE, riskCouncil));
 
     assertTrue(steward.hasRole(AMPLIFICATION_MANAGER_ROLE, ghoCommittee));
     assertTrue(steward.hasRole(FLOAT_RATE_MANAGER_ROLE, ghoCommittee));
@@ -406,6 +413,8 @@ contract sGhoStewardTest is TestSGhoBase {
     vm.expectRevert(abi.encodeWithSelector(IsGhoSteward.MaxRateExceeded.selector));
     steward.setRateConfig(newConfig);
   }
+
+  function test_
 
   function _craftError(address account, bytes32 role) internal pure returns (bytes memory) {
     return

--- a/tests/misc/sGhoSteward.t.sol
+++ b/tests/misc/sGhoSteward.t.sol
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: agpl-3
 pragma solidity ^0.8.19;
 
-import {MockCollector} from '../mocks/MockCollector.sol';
 import {TransparentUpgradeableProxy} from 'openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol';
-import {TestSGhoBase} from '../unit/TestSGhoBase.t.sol';
+import {Collector} from 'aave-v3-origin/contracts/treasury/Collector.sol';
 import {ICollector} from 'aave-v3-origin/contracts/treasury/ICollector.sol';
 
 import {AccessControl} from 'src/contracts/dependencies/openzeppelin-contracts/contracts/access/AccessControl.sol';
@@ -11,13 +10,14 @@ import {Strings} from 'src/contracts/dependencies/openzeppelin-contracts/contrac
 
 import {sGho, IsGho} from 'src/contracts/sgho/sGho.sol';
 import {sGhoSteward, IsGhoSteward} from 'src/contracts/misc/sGhoSteward.sol';
+import {TestSGhoBase} from '../unit/TestSGhoBase.t.sol';
 
 contract sGhoStewardTest is TestSGhoBase {
   sGhoSteward public steward;
 
   address public riskCouncil = makeAddr('riskCouncil');
   address public governance = makeAddr('governance');
-  MockCollector public collector;
+  Collector public collector;
 
   bytes32 public constant YIELD_MANAGER_ROLE = 'YIELD_MANAGER';
 
@@ -32,8 +32,8 @@ contract sGhoStewardTest is TestSGhoBase {
   function setUp() public override {
     super.setUp();
 
-    address collectorImpl = address(new MockCollector());
-    collector = MockCollector(
+    address collectorImpl = address(new Collector());
+    collector = Collector(
       payable(
         new TransparentUpgradeableProxy(
           collectorImpl,
@@ -47,31 +47,22 @@ contract sGhoStewardTest is TestSGhoBase {
       )
     );
 
-    steward = new sGhoSteward(
-      governance,
-      riskCouncil,
-      address(sgho),
-      address(gho),
-      address(collector)
-    );
+    steward = new sGhoSteward(governance, riskCouncil, address(sgho), address(collector));
     sgho.grantRole(sgho.YIELD_MANAGER_ROLE(), address(steward));
   }
 
   function test_wrongSetUp() public {
     vm.expectRevert(abi.encodeWithSelector(IsGhoSteward.ZeroAddress.selector));
-    new sGhoSteward(address(0), riskCouncil, address(sgho), address(gho), address(collector));
+    new sGhoSteward(address(0), riskCouncil, address(sgho), address(collector));
 
     vm.expectRevert(abi.encodeWithSelector(IsGhoSteward.ZeroAddress.selector));
-    new sGhoSteward(governance, address(0), address(sgho), address(gho), address(collector));
+    new sGhoSteward(governance, address(0), address(sgho), address(collector));
 
     vm.expectRevert(abi.encodeWithSelector(IsGhoSteward.ZeroAddress.selector));
-    new sGhoSteward(governance, riskCouncil, address(0), address(gho), address(collector));
+    new sGhoSteward(governance, riskCouncil, address(0), address(collector));
 
     vm.expectRevert(abi.encodeWithSelector(IsGhoSteward.ZeroAddress.selector));
-    new sGhoSteward(governance, riskCouncil, address(sgho), address(0), address(collector));
-
-    vm.expectRevert(abi.encodeWithSelector(IsGhoSteward.ZeroAddress.selector));
-    new sGhoSteward(governance, riskCouncil, address(sgho), address(gho), address(0));
+    new sGhoSteward(governance, riskCouncil, address(sgho), address(0));
   }
 
   function test_initial() public view {

--- a/tests/misc/sGhoSteward.t.sol
+++ b/tests/misc/sGhoSteward.t.sol
@@ -1,15 +1,19 @@
 // SPDX-License-Identifier: agpl-3
 pragma solidity ^0.8.19;
 
+import {IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/IERC20.sol';
 import {TransparentUpgradeableProxy} from 'openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol';
 import {Collector} from 'aave-v3-origin/contracts/treasury/Collector.sol';
 import {ICollector} from 'aave-v3-origin/contracts/treasury/ICollector.sol';
+import {IPoolAddressesProvider} from 'aave-v3-origin/contracts/interfaces/IPoolAddressesProvider.sol';
+import {TestnetERC20} from 'lib/aave-v3-origin/src/contracts/mocks/testnet-helpers/TestnetERC20.sol';
 
 import {AccessControl} from 'src/contracts/dependencies/openzeppelin-contracts/contracts/access/AccessControl.sol';
 import {Strings} from 'src/contracts/dependencies/openzeppelin-contracts/contracts/utils/Strings.sol';
 
 import {sGho, IsGho} from 'src/contracts/sgho/sGho.sol';
 import {sGhoSteward, IsGhoSteward} from 'src/contracts/misc/sGhoSteward.sol';
+import {MockPool} from '../mocks/MockPool.sol';
 import {TestSGhoBase} from '../unit/TestSGhoBase.t.sol';
 
 contract sGhoStewardTest is TestSGhoBase {
@@ -18,6 +22,8 @@ contract sGhoStewardTest is TestSGhoBase {
   address public riskCouncil = makeAddr('riskCouncil');
   address public governance = makeAddr('governance');
   Collector public collector;
+  MockPool public pool;
+  TestnetERC20 public primeGho;
 
   bytes32 public constant YIELD_MANAGER_ROLE = 'YIELD_MANAGER';
 
@@ -28,6 +34,8 @@ contract sGhoStewardTest is TestSGhoBase {
   bytes32 public constant FIXED_RATE_MANAGER_ROLE = keccak256('FIXED_RATE_MANAGER_ROLE');
   bytes32 public constant SUPPLY_CAP_MANAGER_ROLE = keccak256('SUPPLY_CAP_MANAGER_ROLE');
   bytes32 public constant SGHO_FUNDING_ROLE = keccak256('SGHO_FUNDING_ROLE');
+
+  uint256 public constant DEFAULT_MAX_TRANSFER = 1_000_000 ether;
 
   function setUp() public override {
     super.setUp();
@@ -47,22 +55,83 @@ contract sGhoStewardTest is TestSGhoBase {
       )
     );
 
-    steward = new sGhoSteward(governance, riskCouncil, address(sgho), address(collector));
+    pool = new MockPool(IPoolAddressesProvider(address(0)));
+    primeGho = new TestnetERC20('Mock aEthLidoGHO', 'aEthLidoGHO', 18, poolAdmin);
+
+    steward = new sGhoSteward(
+      governance,
+      riskCouncil,
+      address(sgho),
+      address(primeGho),
+      address(collector),
+      address(pool)
+    );
     sgho.grantRole(sgho.YIELD_MANAGER_ROLE(), address(steward));
+
+    // Warp past MINIMUM_DELAY so the debounce check in fundSGho does not block first-time calls.
+    vm.warp(block.timestamp + steward.MINIMUM_DELAY());
   }
 
   function test_wrongSetUp() public {
     vm.expectRevert(abi.encodeWithSelector(IsGhoSteward.ZeroAddress.selector));
-    new sGhoSteward(address(0), riskCouncil, address(sgho), address(collector));
+    new sGhoSteward(
+      address(0),
+      riskCouncil,
+      address(sgho),
+      address(primeGho),
+      address(collector),
+      address(pool)
+    );
 
     vm.expectRevert(abi.encodeWithSelector(IsGhoSteward.ZeroAddress.selector));
-    new sGhoSteward(governance, address(0), address(sgho), address(collector));
+    new sGhoSteward(
+      governance,
+      address(0),
+      address(sgho),
+      address(primeGho),
+      address(collector),
+      address(pool)
+    );
 
     vm.expectRevert(abi.encodeWithSelector(IsGhoSteward.ZeroAddress.selector));
-    new sGhoSteward(governance, riskCouncil, address(0), address(collector));
+    new sGhoSteward(
+      governance,
+      riskCouncil,
+      address(0),
+      address(primeGho),
+      address(collector),
+      address(pool)
+    );
 
     vm.expectRevert(abi.encodeWithSelector(IsGhoSteward.ZeroAddress.selector));
-    new sGhoSteward(governance, riskCouncil, address(sgho), address(0));
+    new sGhoSteward(
+      governance,
+      riskCouncil,
+      address(sgho),
+      address(0),
+      address(collector),
+      address(pool)
+    );
+
+    vm.expectRevert(abi.encodeWithSelector(IsGhoSteward.ZeroAddress.selector));
+    new sGhoSteward(
+      governance,
+      riskCouncil,
+      address(sgho),
+      address(primeGho),
+      address(0),
+      address(pool)
+    );
+
+    vm.expectRevert(abi.encodeWithSelector(IsGhoSteward.ZeroAddress.selector));
+    new sGhoSteward(
+      governance,
+      riskCouncil,
+      address(sgho),
+      address(primeGho),
+      address(collector),
+      address(0)
+    );
   }
 
   function test_initial() public view {
@@ -459,37 +528,152 @@ contract sGhoStewardTest is TestSGhoBase {
     address user = makeAddr('user');
     vm.expectRevert(_craftError(user, SGHO_FUNDING_ROLE));
     vm.prank(user);
-    steward.fundSGho(100_000 ether);
-  }
-
-  function test_fundSGhoNoFunds() public {
-    collector.grantRole(collector.FUNDS_ADMIN_ROLE(), address(steward));
-    vm.expectRevert('ERC20: transfer amount exceeds balance');
-    vm.prank(riskCouncil);
-    steward.fundSGho(100_000 ether);
-  }
-
-  function test_fundSGhoNotFundsAdmin() public {
-    vm.expectRevert(ICollector.OnlyFundsAdmin.selector);
-    vm.prank(riskCouncil);
-    steward.fundSGho(100_000 ether);
+    steward.fundSGho(100_000 ether, false);
   }
 
   function test_fundSGhoZeroAmount() public {
     vm.expectRevert(IsGhoSteward.ZeroAmount.selector);
     vm.prank(riskCouncil);
-    steward.fundSGho(0);
+    steward.fundSGho(0, false);
+  }
+
+  function test_fundSGhoMaxTransferExceeded() public {
+    vm.prank(governance);
+    steward.setMaxTransferAmount(DEFAULT_MAX_TRANSFER);
+
+    vm.expectRevert(
+      abi.encodeWithSelector(IsGhoSteward.MaxTransferExceeded.selector, DEFAULT_MAX_TRANSFER)
+    );
+    vm.prank(riskCouncil);
+    steward.fundSGho(DEFAULT_MAX_TRANSFER + 1, false);
+  }
+
+  function test_fundSGhoMaxTransferExceededDefaultZero() public {
+    // maxTransferAmount defaults to 0, so any non-zero amount must revert with MaxTransferExceeded(0).
+    vm.expectRevert(abi.encodeWithSelector(IsGhoSteward.MaxTransferExceeded.selector, 0));
+    vm.prank(riskCouncil);
+    steward.fundSGho(1, false);
+  }
+
+  function test_fundSGhoNoFunds() public {
+    vm.prank(governance);
+    steward.setMaxTransferAmount(DEFAULT_MAX_TRANSFER);
+
+    collector.grantRole(collector.FUNDS_ADMIN_ROLE(), address(steward));
+    vm.expectRevert('ERC20: transfer amount exceeds balance');
+    vm.prank(riskCouncil);
+    steward.fundSGho(100_000 ether, false);
+  }
+
+  function test_fundSGhoNotFundsAdmin() public {
+    vm.prank(governance);
+    steward.setMaxTransferAmount(DEFAULT_MAX_TRANSFER);
+
+    vm.expectRevert(ICollector.OnlyFundsAdmin.selector);
+    vm.prank(riskCouncil);
+    steward.fundSGho(100_000 ether, false);
+  }
+
+  function test_fundSGhoDebounceNotRespected() public {
+    vm.prank(governance);
+    steward.setMaxTransferAmount(DEFAULT_MAX_TRANSFER);
+
+    collector.grantRole(collector.FUNDS_ADMIN_ROLE(), address(steward));
+    deal(address(gho), address(collector), 200_000 ether);
+
+    // First call succeeds and writes _transferDebounce = block.timestamp.
+    vm.prank(riskCouncil);
+    steward.fundSGho(100_000 ether, false);
+
+    // Second call immediately after must revert with DebounceNotRespected.
+    vm.expectRevert(IsGhoSteward.DebounceNotRespected.selector);
+    vm.prank(riskCouncil);
+    steward.fundSGho(100_000 ether, false);
+
+    // Move past MINIMUM_DELAY and the next call succeeds.
+    vm.warp(block.timestamp + steward.MINIMUM_DELAY());
+
+    vm.prank(riskCouncil);
+    steward.fundSGho(100_000 ether, false);
   }
 
   function test_fundSGho(uint256 amount) public {
+    amount = bound(amount, 1, DEFAULT_MAX_TRANSFER);
+
+    vm.prank(governance);
+    steward.setMaxTransferAmount(DEFAULT_MAX_TRANSFER);
+
     collector.grantRole(collector.FUNDS_ADMIN_ROLE(), address(steward));
-    amount = bound(amount, 1, 1_000_000 ether);
     deal(address(gho), address(collector), amount);
+
+    uint256 sghoBalanceBefore = gho.balanceOf(address(sgho));
 
     vm.expectEmit(true, true, true, true, address(steward));
     emit IsGhoSteward.SGhoFunded(amount);
     vm.prank(riskCouncil);
-    steward.fundSGho(amount);
+    steward.fundSGho(amount, false);
+
+    assertEq(gho.balanceOf(address(sgho)), sghoBalanceBefore + amount);
+    assertEq(gho.balanceOf(address(collector)), 0);
+  }
+
+  function test_fundSGhoWithdrawFromAave(uint256 amount) public {
+    amount = bound(amount, 1, DEFAULT_MAX_TRANSFER);
+
+    vm.prank(governance);
+    steward.setMaxTransferAmount(DEFAULT_MAX_TRANSFER);
+
+    collector.grantRole(collector.FUNDS_ADMIN_ROLE(), address(steward));
+
+    // Collector holds primeGHO (aEthLidoGHO) that the steward will transfer to itself.
+    deal(address(primeGho), address(collector), amount);
+    // MockPool holds GHO so it can fulfill the withdraw call back to the collector.
+    deal(address(gho), address(pool), amount);
+
+    uint256 sghoBalanceBefore = gho.balanceOf(address(sgho));
+
+    vm.expectEmit(true, true, true, true, address(steward));
+    emit IsGhoSteward.SGhoFunded(amount);
+    vm.prank(riskCouncil);
+    steward.fundSGho(amount, true);
+
+    assertEq(gho.balanceOf(address(sgho)), sghoBalanceBefore + amount);
+    assertEq(gho.balanceOf(address(collector)), 0);
+    assertEq(gho.balanceOf(address(pool)), 0);
+    assertEq(primeGho.balanceOf(address(collector)), 0);
+    assertEq(primeGho.balanceOf(address(steward)), amount);
+  }
+
+  function test_setMaxTransferAmountNoRole() public {
+    vm.expectRevert(_craftError(riskCouncil, DEFAULT_ADMIN_ROLE));
+    vm.prank(riskCouncil);
+    steward.setMaxTransferAmount(DEFAULT_MAX_TRANSFER);
+  }
+
+  function test_setMaxTransferAmountUnchanged() public {
+    vm.prank(governance);
+    steward.setMaxTransferAmount(DEFAULT_MAX_TRANSFER);
+
+    vm.expectRevert(IsGhoSteward.MaxTransferAmountUnchanged.selector);
+    vm.prank(governance);
+    steward.setMaxTransferAmount(DEFAULT_MAX_TRANSFER);
+  }
+
+  function test_setMaxTransferAmount() public {
+    assertEq(steward.maxTransferAmount(), 0);
+
+    vm.expectEmit(true, true, true, true, address(steward));
+    emit IsGhoSteward.MaxTransferAmountUpdated(governance, DEFAULT_MAX_TRANSFER);
+    vm.prank(governance);
+    steward.setMaxTransferAmount(DEFAULT_MAX_TRANSFER);
+
+    assertEq(steward.maxTransferAmount(), DEFAULT_MAX_TRANSFER);
+  }
+
+  function test_constants() public view {
+    assertEq(steward.MINIMUM_DELAY(), 2 days);
+    assertEq(steward.AMPLIFICATION_DENOMINATOR(), 100_00);
+    assertEq(steward.MAX_RATE(), sgho.MAX_SAFE_RATE());
   }
 
   function _craftError(address account, bytes32 role) internal pure returns (bytes memory) {

--- a/tests/misc/sGhoSteward.t.sol
+++ b/tests/misc/sGhoSteward.t.sol
@@ -475,6 +475,12 @@ contract sGhoStewardTest is TestSGhoBase {
     steward.fundSGho(100_000 ether);
   }
 
+  function test_fundSGhoZeroAmount() public {
+    vm.expectRevert(IsGhoSteward.ZeroAmount.selector);
+    vm.prank(riskCouncil);
+    steward.fundSGho(0);
+  }
+
   function test_fundSGho(uint256 amount) public {
     collector.grantRole(collector.FUNDS_ADMIN_ROLE(), address(steward));
     amount = bound(amount, 1, 1_000_000 ether);

--- a/tests/misc/sGhoSteward.t.sol
+++ b/tests/misc/sGhoSteward.t.sol
@@ -6,7 +6,6 @@ import {TransparentUpgradeableProxy} from 'openzeppelin-contracts/contracts/prox
 import {Collector} from 'aave-v3-origin/contracts/treasury/Collector.sol';
 import {ICollector} from 'aave-v3-origin/contracts/treasury/ICollector.sol';
 import {IPoolAddressesProvider} from 'aave-v3-origin/contracts/interfaces/IPoolAddressesProvider.sol';
-import {TestnetERC20} from 'lib/aave-v3-origin/src/contracts/mocks/testnet-helpers/TestnetERC20.sol';
 
 import {AccessControl} from 'src/contracts/dependencies/openzeppelin-contracts/contracts/access/AccessControl.sol';
 import {Strings} from 'src/contracts/dependencies/openzeppelin-contracts/contracts/utils/Strings.sol';
@@ -14,6 +13,7 @@ import {Strings} from 'src/contracts/dependencies/openzeppelin-contracts/contrac
 import {sGho, IsGho} from 'src/contracts/sgho/sGho.sol';
 import {sGhoSteward, IsGhoSteward} from 'src/contracts/misc/sGhoSteward.sol';
 import {MockPool} from '../mocks/MockPool.sol';
+import {MockAToken} from '../mocks/MockAToken.sol';
 import {TestSGhoBase} from '../unit/TestSGhoBase.t.sol';
 
 contract sGhoStewardTest is TestSGhoBase {
@@ -23,7 +23,7 @@ contract sGhoStewardTest is TestSGhoBase {
   address public governance = makeAddr('governance');
   Collector public collector;
   MockPool public pool;
-  TestnetERC20 public primeGho;
+  MockAToken public primeGho;
 
   bytes32 public constant YIELD_MANAGER_ROLE = 'YIELD_MANAGER';
 
@@ -34,8 +34,6 @@ contract sGhoStewardTest is TestSGhoBase {
   bytes32 public constant FIXED_RATE_MANAGER_ROLE = keccak256('FIXED_RATE_MANAGER_ROLE');
   bytes32 public constant SUPPLY_CAP_MANAGER_ROLE = keccak256('SUPPLY_CAP_MANAGER_ROLE');
   bytes32 public constant SGHO_FUNDING_ROLE = keccak256('SGHO_FUNDING_ROLE');
-
-  uint256 public constant DEFAULT_MAX_TRANSFER = 1_000_000 ether;
 
   function setUp() public override {
     super.setUp();
@@ -56,7 +54,7 @@ contract sGhoStewardTest is TestSGhoBase {
     );
 
     pool = new MockPool(IPoolAddressesProvider(address(0)));
-    primeGho = new TestnetERC20('Mock aEthLidoGHO', 'aEthLidoGHO', 18, poolAdmin);
+    primeGho = new MockAToken('Mock aEthLidoGHO', 'aEthLidoGHO', 18, poolAdmin, address(pool));
 
     steward = new sGhoSteward(
       governance,
@@ -69,6 +67,7 @@ contract sGhoStewardTest is TestSGhoBase {
     sgho.grantRole(sgho.YIELD_MANAGER_ROLE(), address(steward));
 
     // Warp past MINIMUM_DELAY so the debounce check in fundSGho does not block first-time calls.
+    // block.timestamp on tests starts as 0
     vm.warp(block.timestamp + steward.MINIMUM_DELAY());
   }
 
@@ -148,6 +147,7 @@ contract sGhoStewardTest is TestSGhoBase {
     assertFalse(steward.hasRole(FLOAT_RATE_MANAGER_ROLE, governance));
     assertFalse(steward.hasRole(FIXED_RATE_MANAGER_ROLE, governance));
     assertFalse(steward.hasRole(SUPPLY_CAP_MANAGER_ROLE, governance));
+    assertFalse(steward.hasRole(SGHO_FUNDING_ROLE, governance));
 
     assertEq(address(steward.sGHO()), address(sgho));
   }
@@ -538,27 +538,13 @@ contract sGhoStewardTest is TestSGhoBase {
   }
 
   function test_fundSGhoMaxTransferExceeded() public {
-    vm.prank(governance);
-    steward.setMaxTransferAmount(DEFAULT_MAX_TRANSFER);
-
-    vm.expectRevert(
-      abi.encodeWithSelector(IsGhoSteward.MaxTransferExceeded.selector, DEFAULT_MAX_TRANSFER)
-    );
+    uint256 maxTransfer = steward.getMaxTransferAmount();
+    vm.expectRevert(abi.encodeWithSelector(IsGhoSteward.MaxTransferExceeded.selector, maxTransfer));
     vm.prank(riskCouncil);
-    steward.fundSGho(DEFAULT_MAX_TRANSFER + 1, false);
-  }
-
-  function test_fundSGhoMaxTransferExceededDefaultZero() public {
-    // maxTransferAmount defaults to 0, so any non-zero amount must revert with MaxTransferExceeded(0).
-    vm.expectRevert(abi.encodeWithSelector(IsGhoSteward.MaxTransferExceeded.selector, 0));
-    vm.prank(riskCouncil);
-    steward.fundSGho(1, false);
+    steward.fundSGho(maxTransfer + 1, false);
   }
 
   function test_fundSGhoNoFunds() public {
-    vm.prank(governance);
-    steward.setMaxTransferAmount(DEFAULT_MAX_TRANSFER);
-
     collector.grantRole(collector.FUNDS_ADMIN_ROLE(), address(steward));
     vm.expectRevert('ERC20: transfer amount exceeds balance');
     vm.prank(riskCouncil);
@@ -566,18 +552,12 @@ contract sGhoStewardTest is TestSGhoBase {
   }
 
   function test_fundSGhoNotFundsAdmin() public {
-    vm.prank(governance);
-    steward.setMaxTransferAmount(DEFAULT_MAX_TRANSFER);
-
     vm.expectRevert(ICollector.OnlyFundsAdmin.selector);
     vm.prank(riskCouncil);
     steward.fundSGho(100_000 ether, false);
   }
 
   function test_fundSGhoDebounceNotRespected() public {
-    vm.prank(governance);
-    steward.setMaxTransferAmount(DEFAULT_MAX_TRANSFER);
-
     collector.grantRole(collector.FUNDS_ADMIN_ROLE(), address(steward));
     deal(address(gho), address(collector), 200_000 ether);
 
@@ -598,10 +578,7 @@ contract sGhoStewardTest is TestSGhoBase {
   }
 
   function test_fundSGho(uint256 amount) public {
-    amount = bound(amount, 1, DEFAULT_MAX_TRANSFER);
-
-    vm.prank(governance);
-    steward.setMaxTransferAmount(DEFAULT_MAX_TRANSFER);
+    amount = bound(amount, 1, steward.getMaxTransferAmount());
 
     collector.grantRole(collector.FUNDS_ADMIN_ROLE(), address(steward));
     deal(address(gho), address(collector), amount);
@@ -618,15 +595,13 @@ contract sGhoStewardTest is TestSGhoBase {
   }
 
   function test_fundSGhoWithdrawFromAave(uint256 amount) public {
-    amount = bound(amount, 1, DEFAULT_MAX_TRANSFER);
-
-    vm.prank(governance);
-    steward.setMaxTransferAmount(DEFAULT_MAX_TRANSFER);
+    amount = bound(amount, 1, steward.getMaxTransferAmount());
 
     collector.grantRole(collector.FUNDS_ADMIN_ROLE(), address(steward));
+    pool.setATokenAddress(address(gho), address(primeGho));
 
     // Collector holds primeGHO (aEthLidoGHO) that the steward will transfer to itself.
-    deal(address(primeGho), address(collector), amount);
+    deal(address(primeGho), address(collector), amount, true);
     // MockPool holds GHO so it can fulfill the withdraw call back to the collector.
     deal(address(gho), address(pool), amount);
 
@@ -641,37 +616,36 @@ contract sGhoStewardTest is TestSGhoBase {
     assertEq(gho.balanceOf(address(collector)), 0);
     assertEq(gho.balanceOf(address(pool)), 0);
     assertEq(primeGho.balanceOf(address(collector)), 0);
-    assertEq(primeGho.balanceOf(address(steward)), amount);
+    assertEq(primeGho.balanceOf(address(steward)), 0);
   }
 
   function test_setMaxTransferAmountNoRole() public {
     vm.expectRevert(_craftError(riskCouncil, DEFAULT_ADMIN_ROLE));
     vm.prank(riskCouncil);
-    steward.setMaxTransferAmount(DEFAULT_MAX_TRANSFER);
+    steward.setMaxTransferAmount(1);
   }
 
   function test_setMaxTransferAmountUnchanged() public {
-    vm.prank(governance);
-    steward.setMaxTransferAmount(DEFAULT_MAX_TRANSFER);
-
+    uint256 maxTransferAmount = steward.getMaxTransferAmount();
     vm.expectRevert(IsGhoSteward.MaxTransferAmountUnchanged.selector);
     vm.prank(governance);
-    steward.setMaxTransferAmount(DEFAULT_MAX_TRANSFER);
+    steward.setMaxTransferAmount(maxTransferAmount);
   }
 
   function test_setMaxTransferAmount() public {
-    assertEq(steward.maxTransferAmount(), 0);
+    uint256 maxTransferAmount = steward.getMaxTransferAmount();
+    assertEq(steward.getMaxTransferAmount(), maxTransferAmount);
 
     vm.expectEmit(true, true, true, true, address(steward));
-    emit IsGhoSteward.MaxTransferAmountUpdated(governance, DEFAULT_MAX_TRANSFER);
+    emit IsGhoSteward.MaxTransferAmountUpdated(governance, maxTransferAmount * 2);
     vm.prank(governance);
-    steward.setMaxTransferAmount(DEFAULT_MAX_TRANSFER);
+    steward.setMaxTransferAmount(maxTransferAmount * 2);
 
-    assertEq(steward.maxTransferAmount(), DEFAULT_MAX_TRANSFER);
+    assertEq(steward.getMaxTransferAmount(), maxTransferAmount * 2);
   }
 
   function test_constants() public view {
-    assertEq(steward.MINIMUM_DELAY(), 2 days);
+    assertEq(steward.MINIMUM_DELAY(), 1 days);
     assertEq(steward.AMPLIFICATION_DENOMINATOR(), 100_00);
     assertEq(steward.MAX_RATE(), sgho.MAX_SAFE_RATE());
   }

--- a/tests/mocks/MockAToken.sol
+++ b/tests/mocks/MockAToken.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {TestnetERC20} from 'lib/aave-v3-origin/src/contracts/mocks/testnet-helpers/TestnetERC20.sol';
+
+contract MockAToken is TestnetERC20 {
+  constructor(
+    string memory name,
+    string memory symbol,
+    uint8 decimals,
+    address owner,
+    address pool
+  ) TestnetERC20(name, symbol, decimals, owner) {
+    POOL = pool;
+  }
+
+  address public immutable POOL;
+
+  function burn(address from, uint256 amount) external {
+    require(msg.sender == POOL, 'Only pool');
+    _burn(from, amount);
+  }
+}

--- a/tests/mocks/MockCollector.sol
+++ b/tests/mocks/MockCollector.sol
@@ -1,8 +1,0 @@
-// SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
-
-import {Collector} from 'aave-v3-origin/contracts/treasury/Collector.sol';
-
-contract MockCollector is Collector {
-  constructor() Collector() {}
-}

--- a/tests/mocks/MockPool.sol
+++ b/tests/mocks/MockPool.sol
@@ -5,6 +5,7 @@ import {IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/IERC20.sol';
 import {IPool} from 'aave-v3-origin/contracts/interfaces/IPool.sol';
 import {IPoolAddressesProvider} from 'aave-v3-origin/contracts/interfaces/IPoolAddressesProvider.sol';
 import {DataTypes} from 'aave-v3-origin/contracts/protocol/libraries/types/DataTypes.sol';
+import {MockAToken} from './MockAToken.sol';
 
 /**
  * @dev Minimal MockPool for testing purposes
@@ -51,6 +52,10 @@ contract MockPool {
     _reserves[asset].interestRateStrategyAddress = strategy;
   }
 
+  function setATokenAddress(address asset, address aToken) external {
+    _reserves[asset].aTokenAddress = aToken;
+  }
+
   function deposit(
     address asset,
     uint256 amount,
@@ -58,9 +63,11 @@ contract MockPool {
     uint16 referralCode
   ) external {
     IERC20(asset).transferFrom(msg.sender, onBehalfOf, amount);
+    IERC20(_reserves[asset].aTokenAddress).transfer(msg.sender, amount);
   }
 
   function withdraw(address asset, uint256 amount, address to) external returns (uint256) {
+    MockAToken(_reserves[asset].aTokenAddress).burn(msg.sender, amount);
     IERC20(asset).transfer(to, amount);
 
     return amount;

--- a/tests/mocks/MockPool.sol
+++ b/tests/mocks/MockPool.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import {IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/IERC20.sol';
 import {IPool} from 'aave-v3-origin/contracts/interfaces/IPool.sol';
 import {IPoolAddressesProvider} from 'aave-v3-origin/contracts/interfaces/IPoolAddressesProvider.sol';
 import {DataTypes} from 'aave-v3-origin/contracts/protocol/libraries/types/DataTypes.sol';
@@ -48,5 +49,20 @@ contract MockPool {
 
   function setReserveInterestRateStrategyAddress(address asset, address strategy) external {
     _reserves[asset].interestRateStrategyAddress = strategy;
+  }
+
+  function deposit(
+    address asset,
+    uint256 amount,
+    address onBehalfOf,
+    uint16 referralCode
+  ) external {
+    IERC20(asset).transferFrom(msg.sender, onBehalfOf, amount);
+  }
+
+  function withdraw(address asset, uint256 amount, address to) external returns (uint256) {
+    IERC20(asset).transfer(to, amount);
+
+    return amount;
   }
 }


### PR DESCRIPTION
# Changelog

Add `fundSGho()` method to `sGhoSteward` so it can fund sGHO via the risk council.
We'll add a CRE automation to be able to handle this automatically.

## 1. Objective

`sGHO` is an ERC-4626 vault where users deposit GHO and receive sGHO shares.

As yield accrues, `sGHO.totalAssets()` increases, meaning depositor redemption claims grow over time. However, the actual GHO balance inside the `sGHO` contract does not grow automatically.

The top-up bot keeps the vault solvent by periodically transferring only the missing GHO needed to cover:

1. current depositor liabilities, and
2. a small forward-looking yield buffer.

The key design goal is:

<aside>
💡

**Maintain solvency without unnecessary overfunding.**

</aside>

This matters because GHO transferred into the `sGHO` contract cannot be withdrawn.

